### PR TITLE
tests: fix build with non-default compiler

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -46,6 +46,7 @@ ExternalProject_Add(
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
     INSTALL_COMMAND ""
+    CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
 )
 ExternalProject_Get_Property(gtest source_dir binary_dir)
 add_library(libgtest IMPORTED STATIC GLOBAL)


### PR DESCRIPTION
Without this change, when user sets CC/CXX vars before cmake, they do
not propagate to gtest, which means it's built with default compiler.
This can lead to linking error when the difference between compilers
is big enough.

Ref: marcinslusarz/pmemfile#13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/15)
<!-- Reviewable:end -->
