### PR TITLE
core: remove or mark unused arguments

### DIFF
--- a/src/libpmemfile-core/callbacks.c
+++ b/src/libpmemfile-core/callbacks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -210,6 +210,8 @@ cb_fini(void)
 void
 cb_queue(PMEMobjpool *pop, enum pobj_tx_stage stage, void *arg)
 {
+	(void) pop;
+
 	LOG(15, NULL);
 
 	struct tx_callback_array *cb;

--- a/src/libpmemfile-core/dir.c
+++ b/src/libpmemfile-core/dir.c
@@ -116,7 +116,10 @@ vinode_set_debug_path_locked(PMEMfilepool *pfp,
 		const char *name,
 		size_t namelen)
 {
+	(void) pfp;
+
 #ifdef DEBUG
+
 	if (child_vinode->path)
 		return;
 
@@ -134,6 +137,14 @@ vinode_set_debug_path_locked(PMEMfilepool *pfp,
 	char *p = malloc(strlen(parent_vinode->path) + 1 + namelen + 1);
 	sprintf(p, "%s/%.*s", parent_vinode->path, (int)namelen, name);
 	child_vinode->path = p;
+
+#else
+
+	(void) parent_vinode;
+	(void) child_vinode;
+	(void) name;
+	(void) namelen;
+
 #endif
 }
 
@@ -162,6 +173,8 @@ vinode_set_debug_path(PMEMfilepool *pfp,
 void
 vinode_clear_debug_path(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 {
+	(void) pfp;
+
 	util_rwlock_wrlock(&vinode->rwlock);
 #ifdef DEBUG
 	free(vinode->path);
@@ -184,6 +197,8 @@ vinode_add_dirent(PMEMfilepool *pfp,
 		struct pmemfile_vinode *child_vinode,
 		const struct pmemfile_time *tm)
 {
+	(void) pfp;
+
 	LOG(LDBG, "parent 0x%lx ppath %s name %.*s child_inode 0x%lx",
 		parent_vinode->inode.oid.off, pmfi_path(parent_vinode),
 		(int)namelen, name, child_vinode->inode.oid.off);
@@ -318,6 +333,8 @@ vinode_lookup_dirent_by_name_locked(PMEMfilepool *pfp,
 		struct pmemfile_vinode *parent, const char *name,
 		size_t namelen)
 {
+	(void) pfp;
+
 	LOG(LDBG, "parent 0x%lx ppath %s name %.*s", parent->inode.oid.off,
 			pmfi_path(parent), (int)namelen, name);
 
@@ -357,6 +374,8 @@ static struct pmemfile_dirent *
 vinode_lookup_dirent_by_vinode_locked(PMEMfilepool *pfp,
 		struct pmemfile_vinode *parent,	struct pmemfile_vinode *child)
 {
+	(void) pfp;
+
 	LOG(LDBG, "parent 0x%lx ppath %s", parent->inode.oid.off,
 			pmfi_path(parent));
 
@@ -549,7 +568,7 @@ file_seek_dir(PMEMfile *file, struct pmemfile_dir **dir, unsigned *dirent)
 }
 
 static int
-file_getdents(PMEMfilepool *pfp, PMEMfile *file, struct linux_dirent *dirp,
+file_getdents(PMEMfile *file, struct linux_dirent *dirp,
 		unsigned count)
 {
 	struct pmemfile_dir *dir;
@@ -627,6 +646,8 @@ int
 pmemfile_getdents(PMEMfilepool *pfp, PMEMfile *file,
 			struct linux_dirent *dirp, unsigned count)
 {
+	(void) pfp;
+
 	struct pmemfile_vinode *vinode = file->vinode;
 
 	ASSERT(vinode != NULL);
@@ -648,7 +669,7 @@ pmemfile_getdents(PMEMfilepool *pfp, PMEMfile *file,
 	util_mutex_lock(&file->mutex);
 	util_rwlock_rdlock(&vinode->rwlock);
 
-	bytes_read = file_getdents(pfp, file, dirp, count);
+	bytes_read = file_getdents(file, dirp, count);
 	ASSERT(bytes_read >= 0);
 
 	util_rwlock_unlock(&vinode->rwlock);
@@ -659,7 +680,7 @@ pmemfile_getdents(PMEMfilepool *pfp, PMEMfile *file,
 }
 
 static int
-file_getdents64(PMEMfilepool *pfp, PMEMfile *file, struct linux_dirent64 *dirp,
+file_getdents64(PMEMfile *file, struct linux_dirent64 *dirp,
 		unsigned count)
 {
 	struct pmemfile_dir *dir;
@@ -737,6 +758,8 @@ int
 pmemfile_getdents64(PMEMfilepool *pfp, PMEMfile *file,
 			struct linux_dirent64 *dirp, unsigned count)
 {
+	(void) pfp;
+
 	struct pmemfile_vinode *vinode = file->vinode;
 
 	if (!vinode_is_dir(vinode)) {
@@ -757,7 +780,7 @@ pmemfile_getdents64(PMEMfilepool *pfp, PMEMfile *file,
 	util_mutex_lock(&file->mutex);
 	util_rwlock_rdlock(&vinode->rwlock);
 
-	bytes_read = file_getdents64(pfp, file, dirp, count);
+	bytes_read = file_getdents64(file, dirp, count);
 	ASSERT(bytes_read >= 0);
 
 	util_rwlock_unlock(&vinode->rwlock);

--- a/src/libpmemfile-core/file.c
+++ b/src/libpmemfile-core/file.c
@@ -185,7 +185,7 @@ check_flags(int flags)
 
 static struct pmemfile_vinode *
 create_file(PMEMfilepool *pfp, const char *filename, size_t namelen,
-		const char *full_path, struct pmemfile_vinode *parent_vinode,
+		struct pmemfile_vinode *parent_vinode,
 		int flags, mode_t mode)
 {
 	struct pmemfile_time t;
@@ -207,7 +207,7 @@ create_file(PMEMfilepool *pfp, const char *filename, size_t namelen,
 }
 
 static void
-open_file(const char *orig_pathname, struct pmemfile_vinode *vinode, int flags)
+open_file(struct pmemfile_vinode *vinode, int flags)
 {
 	if ((flags & O_DIRECTORY) && !vinode_is_dir(vinode))
 		pmemfile_tx_abort(ENOTDIR);
@@ -371,9 +371,9 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 	TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
 		if (vinode == NULL) {
 			vinode = create_file(pfp, info.remaining, namelen,
-					orig_pathname, vparent, flags, mode);
+					vparent, flags, mode);
 		} else {
-			open_file(orig_pathname, vinode, flags);
+			open_file(vinode, flags);
 		}
 
 		file = calloc(1, sizeof(*file));

--- a/src/libpmemfile-core/inode.c
+++ b/src/libpmemfile-core/inode.c
@@ -80,6 +80,8 @@ pmfi_path(struct pmemfile_vinode *vinode)
 struct pmemfile_vinode *
 vinode_ref(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 {
+	(void) pfp;
+
 	__sync_fetch_and_add(&vinode->ref, 1);
 	return vinode;
 }
@@ -550,6 +552,8 @@ dir_assert_no_dirents(struct pmemfile_dir *dir)
 void
 inode_free(PMEMfilepool *pfp, TOID(struct pmemfile_inode) tinode)
 {
+	(void) pfp;
+
 	LOG(LDBG, "inode 0x%lx", tinode.oid.off);
 
 	struct pmemfile_inode *inode = D_RW(tinode);

--- a/src/libpmemfile-core/inode_array.c
+++ b/src/libpmemfile-core/inode_array.c
@@ -43,8 +43,7 @@
  * array, inserts it there and returns success status
  */
 static bool
-inode_array_add_single(PMEMfilepool *pfp,
-		struct pmemfile_inode_array *cur,
+inode_array_add_single(struct pmemfile_inode_array *cur,
 		struct pmemfile_vinode *vinode,
 		struct pmemfile_inode_array **ins,
 		unsigned *ins_idx)
@@ -93,7 +92,7 @@ inode_array_add(PMEMfilepool *pfp,
 		pmemobj_mutex_lock_nofail(pfp->pop, &cur->mtx);
 
 		if (cur->used < NUMINODES_PER_ENTRY)
-			found = inode_array_add_single(pfp, cur,
+			found = inode_array_add_single(cur,
 					vinode, ins, ins_idx);
 
 		bool modified = false;

--- a/src/libpmemfile-core/locks.c
+++ b/src/libpmemfile-core/locks.c
@@ -40,6 +40,8 @@
 static void
 file_util_rwlock_unlock(PMEMfilepool *pfp, pthread_rwlock_t *arg)
 {
+	(void) pfp;
+
 	util_rwlock_unlock(arg);
 }
 


### PR DESCRIPTION
Unused arguments removed in the case of static
functions (unless they are used as callback functions),
marked as known unused arguments otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/20)
<!-- Reviewable:end -->
