### PR TITLE
[RFC] posix: port to Windows, part 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,9 @@ add_cxx_flag(-DDEBUG DEBUG)
 add_c_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE C_CAN_FORTIFY)
 add_cxx_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE CXX_CAN_FORTIFY)
 
+add_c_flag(-D_LARGEFILE64_SOURCE)
+add_cxx_flag(-D_LARGEFILE64_SOURCE)
+
 option(SANITIZERS "enable AddressSanitizer and UndefinedBehaviorSanitizer (debugging)" OFF)
 
 if(SANITIZERS)

--- a/doc/libpmemfile-posix.3.md
+++ b/doc/libpmemfile-posix.3.md
@@ -187,11 +187,6 @@ ssize_t pmemfile_pwritev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *
 off_t pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, off_t offset,
                 int whence);
 
-#ifdef __off64_t_defined
-off64_t pmemfile_lseek64(PMEMfilepool *pfp, PMEMfile *file, off64_t offset,
-                int whence);
-#endif
-
 int pmemfile_truncate(PMEMfilepool *pfp, const char *path, off_t length);
 int pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, off_t length);
 ```

--- a/include/libpmemfile-posix-stubs.h
+++ b/include/libpmemfile-posix-stubs.h
@@ -65,29 +65,34 @@ void *pmemfile_mremap(PMEMfilepool *, void *old_addr, size_t old_size,
 int pmemfile_msync(PMEMfilepool *, void *addr, size_t len, int flags);
 int pmemfile_mprotect(PMEMfilepool *, void *addr, size_t len, int prot);
 
-struct iovec;
-pmemfile_ssize_t pmemfile_readv(PMEMfilepool *, PMEMfile *file,
-	const struct iovec *iov, int iovcnt);
-pmemfile_ssize_t pmemfile_writev(PMEMfilepool *, PMEMfile *file,
-	const struct iovec *iov, int iovcnt);
-pmemfile_ssize_t pmemfile_preadv(PMEMfilepool *, PMEMfile *file,
-	const struct iovec *iov, int iovcnt, pmemfile_off_t offset);
-pmemfile_ssize_t pmemfile_pwritev(PMEMfilepool *, PMEMfile *file,
-	const struct iovec *iov, int iovcnt, pmemfile_off_t offset);
+typedef struct iovec pmemfile_iovec_t;
 
-struct utimbuf;
+pmemfile_ssize_t pmemfile_readv(PMEMfilepool *, PMEMfile *file,
+	const pmemfile_iovec_t *iov, int iovcnt);
+pmemfile_ssize_t pmemfile_writev(PMEMfilepool *, PMEMfile *file,
+	const pmemfile_iovec_t *iov, int iovcnt);
+pmemfile_ssize_t pmemfile_preadv(PMEMfilepool *, PMEMfile *file,
+	const pmemfile_iovec_t *iov, int iovcnt, pmemfile_off_t offset);
+pmemfile_ssize_t pmemfile_pwritev(PMEMfilepool *, PMEMfile *file,
+	const pmemfile_iovec_t *iov, int iovcnt, pmemfile_off_t offset);
+
+typedef struct utimbuf pmemfile_utimbuf_t;
+
 int pmemfile_utime(PMEMfilepool *, const char *filename,
-		const struct utimbuf *times);
+		const pmemfile_utimbuf_t *times);
+
+typedef struct timeval pmemfile_timeval_t;
+
 int pmemfile_utimes(PMEMfilepool *, const char *filename,
-		const struct timeval times[2]);
+		const pmemfile_timeval_t times[2]);
 int pmemfile_futimes(PMEMfilepool *, PMEMfile *file,
-		const struct timeval tv[2]);
+		const pmemfile_timeval_t tv[2]);
 int pmemfile_lutimes(PMEMfilepool *, const char *filename,
-		const struct timeval tv[2]);
+		const pmemfile_timeval_t tv[2]);
 int pmemfile_utimensat(PMEMfilepool *, PMEMfile *dir, const char *pathname,
-		const struct timespec times[2], int flags);
+		const pmemfile_timespec_t times[2], int flags);
 int pmemfile_futimens(PMEMfilepool *, PMEMfile *file,
-		const struct timespec times[2]);
+		const pmemfile_timespec_t times[2]);
 
 pmemfile_mode_t pmemfile_umask(PMEMfilepool *, pmemfile_mode_t mask);
 

--- a/include/libpmemfile-posix-stubs.h
+++ b/include/libpmemfile-posix-stubs.h
@@ -58,7 +58,7 @@ PMEMfile *pmemfile_dup2(PMEMfilepool *, PMEMfile *file, PMEMfile *file2);
 
 // Memory mapping pmemfiles, these need extra suppport in the preloadable lib
 void *pmemfile_mmap(PMEMfilepool *, void *addr, size_t len,
-		int prot, int flags, PMEMfile *file, off_t off);
+		int prot, int flags, PMEMfile *file, pmemfile_off_t off);
 int pmemfile_munmap(PMEMfilepool *, void *addr, size_t len);
 void *pmemfile_mremap(PMEMfilepool *, void *old_addr, size_t old_size,
 			size_t new_size, int flags, void *new_addr);
@@ -66,14 +66,14 @@ int pmemfile_msync(PMEMfilepool *, void *addr, size_t len, int flags);
 int pmemfile_mprotect(PMEMfilepool *, void *addr, size_t len, int prot);
 
 struct iovec;
-ssize_t pmemfile_readv(PMEMfilepool *, PMEMfile *file,
+pmemfile_ssize_t pmemfile_readv(PMEMfilepool *, PMEMfile *file,
 	const struct iovec *iov, int iovcnt);
-ssize_t pmemfile_writev(PMEMfilepool *, PMEMfile *file,
+pmemfile_ssize_t pmemfile_writev(PMEMfilepool *, PMEMfile *file,
 	const struct iovec *iov, int iovcnt);
-ssize_t pmemfile_preadv(PMEMfilepool *, PMEMfile *file,
-	const struct iovec *iov, int iovcnt, off_t offset);
-ssize_t pmemfile_pwritev(PMEMfilepool *, PMEMfile *file,
-	const struct iovec *iov, int iovcnt, off_t offset);
+pmemfile_ssize_t pmemfile_preadv(PMEMfilepool *, PMEMfile *file,
+	const struct iovec *iov, int iovcnt, pmemfile_off_t offset);
+pmemfile_ssize_t pmemfile_pwritev(PMEMfilepool *, PMEMfile *file,
+	const struct iovec *iov, int iovcnt, pmemfile_off_t offset);
 
 struct utimbuf;
 int pmemfile_utime(PMEMfilepool *, const char *filename,
@@ -89,11 +89,11 @@ int pmemfile_utimensat(PMEMfilepool *, PMEMfile *dir, const char *pathname,
 int pmemfile_futimens(PMEMfilepool *, PMEMfile *file,
 		const struct timespec times[2]);
 
-mode_t pmemfile_umask(PMEMfilepool *, mode_t mask);
+pmemfile_mode_t pmemfile_umask(PMEMfilepool *, pmemfile_mode_t mask);
 
-ssize_t pmemfile_copy_file_range(PMEMfilepool *,
-		PMEMfile *file_in, loff_t *off_in,
-		PMEMfile *file_out, loff_t *off_out,
+pmemfile_ssize_t pmemfile_copy_file_range(PMEMfilepool *,
+		PMEMfile *file_in, pmemfile_off_t *off_in,
+		PMEMfile *file_out, pmemfile_off_t *off_out,
 		size_t len, unsigned flags);
 
 /*

--- a/include/libpmemfile-posix.h
+++ b/include/libpmemfile-posix.h
@@ -207,11 +207,6 @@ ssize_t pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf,
 off_t pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, off_t offset,
 		int whence);
 
-#ifdef __off64_t_defined
-off64_t pmemfile_lseek64(PMEMfilepool *pfp, PMEMfile *file, off64_t offset,
-		int whence);
-#endif
-
 ssize_t pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
 		size_t count, off_t offset);
 

--- a/include/libpmemfile-posix.h
+++ b/include/libpmemfile-posix.h
@@ -170,9 +170,24 @@ extern "C" {
 typedef struct pmemfilepool PMEMfilepool;
 typedef struct pmemfile_file PMEMfile;
 
+typedef mode_t pmemfile_mode_t;
+typedef uid_t pmemfile_uid_t;
+typedef gid_t pmemfile_gid_t;
+typedef ssize_t pmemfile_ssize_t;
+#ifndef __off64_t_defined
+#error off64_t is not available, on glibc enable _LARGEFILE64_SOURCE, _XOPEN_SOURCE>=500 or _GNU_SOURCE to define it
+#endif
+typedef off64_t pmemfile_off_t;
+typedef nlink_t pmemfile_nlink_t;
+typedef blksize_t pmemfile_blksize_t;
+typedef blkcnt64_t pmemfile_blkcnt_t;
+typedef dev_t pmemfile_dev_t;
+typedef ino64_t pmemfile_ino_t;
+
 #define PMEMFILE_AT_CWD ((PMEMfile *)(((unsigned char *)0) - 1))
 
-PMEMfilepool *pmemfile_mkfs(const char *pathname, size_t poolsize, mode_t mode);
+PMEMfilepool *pmemfile_mkfs(const char *pathname, size_t poolsize,
+		pmemfile_mode_t mode);
 
 PMEMfilepool *pmemfile_pool_open(const char *pathname);
 void pmemfile_pool_close(PMEMfilepool *pfp);
@@ -181,7 +196,8 @@ PMEMfile *pmemfile_open(PMEMfilepool *pfp, const char *pathname, int flags,
 		...);
 PMEMfile *pmemfile_openat(PMEMfilepool *pfp, PMEMfile *dir,
 		const char *pathname, int flags, ...);
-PMEMfile *pmemfile_create(PMEMfilepool *pfp, const char *pathname, mode_t mode);
+PMEMfile *pmemfile_create(PMEMfilepool *pfp, const char *pathname,
+		pmemfile_mode_t mode);
 /* XXX Should we get rid of PMEMfilepool pointer? */
 void pmemfile_close(PMEMfilepool *pfp, PMEMfile *file);
 
@@ -198,20 +214,20 @@ int pmemfile_renameat(PMEMfilepool *, PMEMfile *old_at, const char *old_path,
 int pmemfile_renameat2(PMEMfilepool *, PMEMfile *old_at, const char *old_path,
 		PMEMfile *new_at, const char *new_path, unsigned flags);
 
-ssize_t pmemfile_write(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
+pmemfile_ssize_t pmemfile_write(PMEMfilepool *pfp, PMEMfile *file,
+		const void *buf, size_t count);
+
+pmemfile_ssize_t pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf,
 		size_t count);
 
-ssize_t pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf,
-		size_t count);
+pmemfile_off_t pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file,
+		pmemfile_off_t offset, int whence);
 
-off_t pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, off_t offset,
-		int whence);
+pmemfile_ssize_t pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file,
+		const void *buf, size_t count, pmemfile_off_t offset);
 
-ssize_t pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
-		size_t count, off_t offset);
-
-ssize_t pmemfile_pread(PMEMfilepool *pfp, PMEMfile *file, void *buf,
-		size_t count, off_t offset);
+pmemfile_ssize_t pmemfile_pread(PMEMfilepool *pfp, PMEMfile *file, void *buf,
+		size_t count, pmemfile_off_t offset);
 
 int pmemfile_stat(PMEMfilepool *, const char *path, struct stat *buf);
 int pmemfile_lstat(PMEMfilepool *, const char *path, struct stat *buf);
@@ -225,9 +241,9 @@ int pmemfile_getdents(PMEMfilepool *, PMEMfile *file,
 			struct linux_dirent *dirp, unsigned count);
 int pmemfile_getdents64(PMEMfilepool *, PMEMfile *file,
 			struct linux_dirent64 *dirp, unsigned count);
-int pmemfile_mkdir(PMEMfilepool *, const char *path, mode_t mode);
+int pmemfile_mkdir(PMEMfilepool *, const char *path, pmemfile_mode_t mode);
 int pmemfile_mkdirat(PMEMfilepool *, PMEMfile *dir, const char *path,
-		mode_t mode);
+		pmemfile_mode_t mode);
 int pmemfile_rmdir(PMEMfilepool *, const char *path);
 
 int pmemfile_chdir(PMEMfilepool *, const char *path);
@@ -239,42 +255,43 @@ int pmemfile_symlink(PMEMfilepool *, const char *path1, const char *path2);
 int pmemfile_symlinkat(PMEMfilepool *, const char *path1,
 				PMEMfile *at, const char *path2);
 
-ssize_t pmemfile_readlink(PMEMfilepool *, const char *path,
+pmemfile_ssize_t pmemfile_readlink(PMEMfilepool *, const char *path,
 			char *buf, size_t buf_len);
-ssize_t pmemfile_readlinkat(PMEMfilepool *, PMEMfile *dir, const char *pathname,
-			char *buf, size_t bufsiz);
+pmemfile_ssize_t pmemfile_readlinkat(PMEMfilepool *, PMEMfile *dir,
+			const char *pathname, char *buf, size_t bufsiz);
 
-int pmemfile_chmod(PMEMfilepool *, const char *path, mode_t mode);
-int pmemfile_fchmod(PMEMfilepool *, PMEMfile *, mode_t mode);
+int pmemfile_chmod(PMEMfilepool *, const char *path, pmemfile_mode_t mode);
+int pmemfile_fchmod(PMEMfilepool *, PMEMfile *, pmemfile_mode_t mode);
 int pmemfile_fchmodat(PMEMfilepool *, PMEMfile *dir, const char *pathname,
-	mode_t mode, int flags);
+		pmemfile_mode_t mode, int flags);
 
-int pmemfile_setreuid(PMEMfilepool *, uid_t ruid, uid_t euid);
-int pmemfile_setregid(PMEMfilepool *, gid_t rgid, gid_t egid);
+int pmemfile_setreuid(PMEMfilepool *, pmemfile_uid_t ruid, pmemfile_uid_t euid);
+int pmemfile_setregid(PMEMfilepool *, pmemfile_gid_t rgid, pmemfile_gid_t egid);
 
-int pmemfile_setuid(PMEMfilepool *, uid_t uid);
-int pmemfile_setgid(PMEMfilepool *, gid_t gid);
-uid_t pmemfile_getuid(PMEMfilepool *);
-gid_t pmemfile_getgid(PMEMfilepool *);
+int pmemfile_setuid(PMEMfilepool *, pmemfile_uid_t uid);
+int pmemfile_setgid(PMEMfilepool *, pmemfile_gid_t gid);
+pmemfile_uid_t pmemfile_getuid(PMEMfilepool *);
+pmemfile_gid_t pmemfile_getgid(PMEMfilepool *);
 
-int pmemfile_seteuid(PMEMfilepool *, uid_t uid);
-int pmemfile_setegid(PMEMfilepool *, gid_t gid);
-uid_t pmemfile_geteuid(PMEMfilepool *);
-gid_t pmemfile_getegid(PMEMfilepool *);
+int pmemfile_seteuid(PMEMfilepool *, pmemfile_uid_t uid);
+int pmemfile_setegid(PMEMfilepool *, pmemfile_gid_t gid);
+pmemfile_uid_t pmemfile_geteuid(PMEMfilepool *);
+pmemfile_gid_t pmemfile_getegid(PMEMfilepool *);
 
-int pmemfile_setfsuid(PMEMfilepool *, uid_t fsuid);
-int pmemfile_setfsgid(PMEMfilepool *, uid_t fsgid);
+int pmemfile_setfsuid(PMEMfilepool *, pmemfile_uid_t fsuid);
+int pmemfile_setfsgid(PMEMfilepool *, pmemfile_uid_t fsgid);
 
-int pmemfile_getgroups(PMEMfilepool *, int size, gid_t list[]);
-int pmemfile_setgroups(PMEMfilepool *, size_t size, const gid_t *list);
+int pmemfile_getgroups(PMEMfilepool *, int size, pmemfile_gid_t list[]);
+int pmemfile_setgroups(PMEMfilepool *, size_t size, const pmemfile_gid_t *list);
 
-int pmemfile_chown(PMEMfilepool *, const char *pathname, uid_t owner,
-		gid_t group);
-int pmemfile_fchown(PMEMfilepool *, PMEMfile *file, uid_t owner, gid_t group);
-int pmemfile_lchown(PMEMfilepool *, const char *pathname, uid_t owner,
-		gid_t group);
+int pmemfile_chown(PMEMfilepool *, const char *pathname, pmemfile_uid_t owner,
+		pmemfile_gid_t group);
+int pmemfile_fchown(PMEMfilepool *, PMEMfile *file, pmemfile_uid_t owner,
+		pmemfile_gid_t group);
+int pmemfile_lchown(PMEMfilepool *, const char *pathname, pmemfile_uid_t owner,
+		pmemfile_gid_t group);
 int pmemfile_fchownat(PMEMfilepool *, PMEMfile *dir, const char *pathname,
-		uid_t owner, gid_t group, int flags);
+		pmemfile_uid_t owner, pmemfile_gid_t group, int flags);
 
 int pmemfile_access(PMEMfilepool *, const char *path, int mode);
 int pmemfile_euidaccess(PMEMfilepool *, const char *pathname, int mode);
@@ -295,8 +312,8 @@ struct pmemfile_stats {
 };
 void pmemfile_stats(PMEMfilepool *pfp, struct pmemfile_stats *stats);
 
-int pmemfile_truncate(PMEMfilepool *, const char *path, off_t length);
-int pmemfile_ftruncate(PMEMfilepool *, PMEMfile *file, off_t length);
+int pmemfile_truncate(PMEMfilepool *, const char *path, pmemfile_off_t length);
+int pmemfile_ftruncate(PMEMfilepool *, PMEMfile *file, pmemfile_off_t length);
 
 /*
  * Not in POSIX:
@@ -304,10 +321,10 @@ int pmemfile_ftruncate(PMEMfilepool *, PMEMfile *file, off_t length);
  * The pmemfile_fallocate supports allocating, and punching holes.
  */
 int pmemfile_fallocate(PMEMfilepool *, PMEMfile *file, int mode,
-		off_t offset, off_t length);
+		pmemfile_off_t offset, pmemfile_off_t length);
 
 int pmemfile_posix_fallocate(PMEMfilepool *pfp, PMEMfile *file,
-		off_t offset, off_t length);
+		pmemfile_off_t offset, pmemfile_off_t length);
 
 char *pmemfile_get_dir_path(PMEMfilepool *pfp, PMEMfile *dir, char *buf,
 		size_t size);

--- a/include/libpmemfile-posix.h
+++ b/include/libpmemfile-posix.h
@@ -184,6 +184,9 @@ typedef blkcnt64_t pmemfile_blkcnt_t;
 typedef dev_t pmemfile_dev_t;
 typedef ino64_t pmemfile_ino_t;
 
+typedef struct timespec pmemfile_timespec_t;
+typedef struct stat pmemfile_stat_t;
+
 #define PMEMFILE_AT_CWD ((PMEMfile *)(((unsigned char *)0) - 1))
 
 PMEMfilepool *pmemfile_mkfs(const char *pathname, size_t poolsize,
@@ -229,11 +232,11 @@ pmemfile_ssize_t pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file,
 pmemfile_ssize_t pmemfile_pread(PMEMfilepool *pfp, PMEMfile *file, void *buf,
 		size_t count, pmemfile_off_t offset);
 
-int pmemfile_stat(PMEMfilepool *, const char *path, struct stat *buf);
-int pmemfile_lstat(PMEMfilepool *, const char *path, struct stat *buf);
-int pmemfile_fstat(PMEMfilepool *, PMEMfile *file, struct stat *buf);
+int pmemfile_stat(PMEMfilepool *, const char *path, pmemfile_stat_t *buf);
+int pmemfile_lstat(PMEMfilepool *, const char *path, pmemfile_stat_t *buf);
+int pmemfile_fstat(PMEMfilepool *, PMEMfile *file, pmemfile_stat_t *buf);
 int pmemfile_fstatat(PMEMfilepool *, PMEMfile *dir, const char *path,
-		struct stat *buf, int flags);
+		pmemfile_stat_t *buf, int flags);
 
 struct linux_dirent;
 struct linux_dirent64;

--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -577,7 +577,7 @@ file_write(PMEMfilepool *pfp, PMEMfile *file, struct pmemfile_inode *inode,
 	}
 }
 
-static ssize_t
+static pmemfile_ssize_t
 pmemfile_write_locked(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
 		size_t count)
 {
@@ -593,7 +593,7 @@ pmemfile_write_locked(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
 		return -1;
 	}
 
-	if ((ssize_t)count < 0)    /* Normally this will still   */
+	if ((pmemfile_ssize_t)count < 0)    /* Normally this will still   */
 		count = SSIZE_MAX; /* try to write 2^63 bytes... */
 
 	if (file->offset + count < file->offset) /* overflow check */
@@ -639,16 +639,16 @@ pmemfile_write_locked(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
 		return -1;
 	}
 
-	return (ssize_t)count;
+	return (pmemfile_ssize_t)count;
 }
 
 /*
  * pmemfile_write -- writes to file
  */
-ssize_t
+pmemfile_ssize_t
 pmemfile_write(PMEMfilepool *pfp, PMEMfile *file, const void *buf, size_t count)
 {
-	ssize_t ret;
+	pmemfile_ssize_t ret;
 
 	os_mutex_lock(&file->mutex);
 	ret = pmemfile_write_locked(pfp, file, buf, count);
@@ -698,7 +698,7 @@ time_cmp(const struct pmemfile_time *t1, const struct pmemfile_time *t2)
 	return 0;
 }
 
-static ssize_t
+static pmemfile_ssize_t
 pmemfile_read_locked(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
 {
 	LOG(LDBG, "file %p buf %p count %zu", file, buf, count);
@@ -713,7 +713,7 @@ pmemfile_read_locked(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
 		return -1;
 	}
 
-	if ((ssize_t)count < 0)
+	if ((pmemfile_ssize_t)count < 0)
 		count = SSIZE_MAX;
 
 	size_t bytes_read = 0;
@@ -766,16 +766,16 @@ pmemfile_read_locked(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
 	file->offset += bytes_read;
 
 	ASSERT(bytes_read <= count);
-	return (ssize_t)bytes_read;
+	return (pmemfile_ssize_t)bytes_read;
 }
 
 /*
  * pmemfile_read -- reads file
  */
-ssize_t
+pmemfile_ssize_t
 pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
 {
-	ssize_t ret;
+	pmemfile_ssize_t ret;
 
 	os_mutex_lock(&file->mutex);
 	ret = pmemfile_read_locked(pfp, file, buf, count);
@@ -788,8 +788,9 @@ pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
  * lseek_seek_data -- part of the lseek implementation
  * Looks for data (not a hole), starting at the specified offset.
  */
-static off64_t
-lseek_seek_data(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
+static pmemfile_off_t
+lseek_seek_data(struct pmemfile_vinode *vinode, pmemfile_off_t offset,
+		pmemfile_off_t fsize)
 {
 	if (vinode->blocks == NULL)
 		vinode_rebuild_block_tree(vinode);
@@ -800,7 +801,7 @@ lseek_seek_data(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
 		if (vinode->first_block == NULL)
 			return fsize; /* No data in the whole file */
 		else
-			return (off64_t)vinode->first_block->offset;
+			return (pmemfile_off_t)vinode->first_block->offset;
 	}
 
 	if (is_offset_in_block(block, (uint64_t)offset))
@@ -811,15 +812,16 @@ lseek_seek_data(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
 	if (block == NULL)
 		return fsize; /* No more data in file */
 
-	return (off64_t)block->offset;
+	return (pmemfile_off_t)block->offset;
 }
 
 /*
  * lseek_seek_hole -- part of the lseek implementation
  * Looks for a hole, starting at the specified offset.
  */
-static off64_t
-lseek_seek_hole(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
+static pmemfile_off_t
+lseek_seek_hole(struct pmemfile_vinode *vinode, pmemfile_off_t offset,
+		pmemfile_off_t fsize)
 {
 	if (vinode->blocks == NULL)
 		vinode_rebuild_block_tree(vinode);
@@ -827,7 +829,8 @@ lseek_seek_hole(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
 	struct pmemfile_block *block = find_block(vinode, (uint64_t)offset);
 
 	while (block != NULL && offset < fsize) {
-		off64_t block_end = (off64_t)block->offset + block->size;
+		pmemfile_off_t block_end =
+				(pmemfile_off_t)block->offset + block->size;
 
 		struct pmemfile_block *next = D_RW(block->next);
 
@@ -836,7 +839,7 @@ lseek_seek_hole(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
 
 		if (next == NULL)
 			break; /* the rest of the file is treated as a hole */
-		else if (offset < (off64_t)next->offset)
+		else if (offset < (pmemfile_off_t)next->offset)
 			break; /* offset is in a hole between two blocks */
 
 		block = next;
@@ -849,11 +852,11 @@ lseek_seek_hole(struct pmemfile_vinode *vinode, off64_t offset, off64_t fsize)
  * lseek_seek_data_or_hole -- part of the lseek implementation
  * Expects the vinode to be locked while being called.
  */
-static off64_t
-lseek_seek_data_or_hole(struct pmemfile_vinode *vinode, off64_t offset,
+static pmemfile_off_t
+lseek_seek_data_or_hole(struct pmemfile_vinode *vinode, pmemfile_off_t offset,
 			int whence)
 {
-	ssize_t fsize = (off64_t)vinode->inode->size;
+	pmemfile_ssize_t fsize = (pmemfile_ssize_t)vinode->inode->size;
 
 	if (!vinode_is_regular_file(vinode))
 		return -EBADF; /* XXX directories are not supported here yet */
@@ -880,13 +883,13 @@ lseek_seek_data_or_hole(struct pmemfile_vinode *vinode, off64_t offset,
 /*
  * pmemfile_lseek_locked -- changes file current offset
  */
-static off64_t
-pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, off64_t offset,
+static pmemfile_off_t
+pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t offset,
 		int whence)
 {
 	(void) pfp;
 
-	LOG(LDBG, "file %p offset %lu whence %d", file, offset, whence);
+	LOG(LDBG, "file %p offset %ld whence %d", file, offset, whence);
 
 	if (file->flags & PFILE_PATH) {
 		errno = EBADF;
@@ -907,7 +910,7 @@ pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, off64_t offset,
 
 	struct pmemfile_vinode *vinode = file->vinode;
 	struct pmemfile_inode *inode = vinode->inode;
-	off64_t ret;
+	pmemfile_off_t ret;
 	int new_errno = EINVAL;
 
 	switch (whence) {
@@ -915,11 +918,11 @@ pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, off64_t offset,
 			ret = offset;
 			break;
 		case PMEMFILE_SEEK_CUR:
-			ret = (off64_t)file->offset + offset;
+			ret = (pmemfile_off_t)file->offset + offset;
 			break;
 		case PMEMFILE_SEEK_END:
 			os_rwlock_rdlock(&vinode->rwlock);
-			ret = (off64_t)inode->size + offset;
+			ret = (pmemfile_off_t)inode->size + offset;
 			os_rwlock_unlock(&vinode->rwlock);
 			break;
 		case PMEMFILE_SEEK_DATA:
@@ -953,11 +956,12 @@ pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, off64_t offset,
 /*
  * pmemfile_lseek -- changes file current offset
  */
-off_t
-pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, off_t offset, int whence)
+pmemfile_off_t
+pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t offset,
+		int whence)
 {
 	COMPILE_ERROR_ON(sizeof(offset) != 8);
-	off_t ret;
+	pmemfile_off_t ret;
 
 	os_mutex_lock(&file->mutex);
 	ret = pmemfile_lseek_locked(pfp, file, offset, whence);
@@ -966,12 +970,12 @@ pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, off_t offset, int whence)
 	return ret;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_pread(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count,
-		off_t offset)
+		pmemfile_off_t offset)
 {
 	/* XXX this is hacky implementation */
-	ssize_t ret;
+	pmemfile_ssize_t ret;
 	os_mutex_lock(&file->mutex);
 
 	size_t cur_off = file->offset;
@@ -992,12 +996,12 @@ end:
 	return ret;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
-		size_t count, off_t offset)
+		size_t count, pmemfile_off_t offset)
 {
 	/* XXX this is hacky implementation */
-	ssize_t ret;
+	pmemfile_ssize_t ret;
 	os_mutex_lock(&file->mutex);
 
 	size_t cur_off = file->offset;

--- a/src/libpmemfile-posix/dir.c
+++ b/src/libpmemfile-posix/dir.c
@@ -302,7 +302,7 @@ vinode_add_dirent(PMEMfilepool *pfp,
  */
 struct pmemfile_vinode *
 vinode_new_dir(PMEMfilepool *pfp, struct pmemfile_vinode *parent,
-		const char *name, size_t namelen, mode_t mode,
+		const char *name, size_t namelen, pmemfile_mode_t mode,
 		bool add_to_parent, volatile bool *parent_refed)
 {
 	LOG(LDBG, "parent 0x%" PRIx64 " ppath %s new_name %.*s",
@@ -311,7 +311,7 @@ vinode_new_dir(PMEMfilepool *pfp, struct pmemfile_vinode *parent,
 
 	ASSERTeq(pmemobj_tx_stage(), TX_STAGE_WORK);
 
-	if (mode & ~(mode_t)PMEMFILE_ACCESSPERMS) {
+	if (mode & ~(pmemfile_mode_t)PMEMFILE_ACCESSPERMS) {
 		/* XXX: what the kernel does in this case? */
 		ERR("invalid mode flags 0%o", mode);
 		pmemfile_tx_abort(EINVAL);
@@ -1018,7 +1018,7 @@ path_info_cleanup(PMEMfilepool *pfp, struct pmemfile_path_info *path_info)
 
 static int
 _pmemfile_mkdirat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
-		const char *path, mode_t mode)
+		const char *path, pmemfile_mode_t mode)
 {
 	struct pmemfile_path_info info;
 	struct pmemfile_cred cred;
@@ -1095,7 +1095,7 @@ vinode_cleanup(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 
 int
 pmemfile_mkdirat(PMEMfilepool *pfp, PMEMfile *dir, const char *path,
-		mode_t mode)
+		pmemfile_mode_t mode)
 {
 	struct pmemfile_vinode *at;
 	bool at_unref;
@@ -1116,7 +1116,7 @@ pmemfile_mkdirat(PMEMfilepool *pfp, PMEMfile *dir, const char *path,
 }
 
 int
-pmemfile_mkdir(PMEMfilepool *pfp, const char *path, mode_t mode)
+pmemfile_mkdir(PMEMfilepool *pfp, const char *path, pmemfile_mode_t mode)
 {
 	return pmemfile_mkdirat(pfp, PMEMFILE_AT_CWD, path, mode);
 }

--- a/src/libpmemfile-posix/dir.h
+++ b/src/libpmemfile-posix/dir.h
@@ -72,7 +72,7 @@ size_t component_length(const char *path);
 
 struct pmemfile_vinode *vinode_new_dir(PMEMfilepool *pfp,
 		struct pmemfile_vinode *parent, const char *name,
-		size_t namelen, mode_t mode, bool add_to_parent,
+		size_t namelen, pmemfile_mode_t mode, bool add_to_parent,
 		volatile bool *parent_refed);
 
 void vinode_add_dirent(PMEMfilepool *pfp,

--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -174,7 +174,7 @@ check_flags(int flags)
 static struct pmemfile_vinode *
 create_file(PMEMfilepool *pfp, struct pmemfile_cred *cred, const char *filename,
 		size_t namelen, struct pmemfile_vinode *parent_vinode,
-		int flags, mode_t mode)
+		int flags, pmemfile_mode_t mode)
 {
 	rwlock_tx_wlock(&parent_vinode->rwlock);
 
@@ -261,11 +261,11 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 
 	va_list ap;
 	va_start(ap, flags);
-	mode_t mode = 0;
+	pmemfile_mode_t mode = 0;
 
 	/* NOTE: O_TMPFILE contains O_DIRECTORY */
 	if ((flags & PMEMFILE_O_CREAT) || is_tmpfile(flags)) {
-		mode = va_arg(ap, mode_t);
+		mode = va_arg(ap, pmemfile_mode_t);
 		LOG(LDBG, "mode %o", mode);
 		mode &= PMEMFILE_ALLPERMS;
 	}
@@ -446,9 +446,9 @@ pmemfile_openat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 
 	va_list ap;
 	va_start(ap, flags);
-	mode_t mode = 0;
+	pmemfile_mode_t mode = 0;
 	if ((flags & PMEMFILE_O_CREAT) || is_tmpfile(flags))
-		mode = va_arg(ap, mode_t);
+		mode = va_arg(ap, pmemfile_mode_t);
 	va_end(ap);
 
 	struct pmemfile_vinode *at;
@@ -472,16 +472,16 @@ pmemfile_open(PMEMfilepool *pfp, const char *pathname, int flags, ...)
 {
 	va_list ap;
 	va_start(ap, flags);
-	mode_t mode = 0;
+	pmemfile_mode_t mode = 0;
 	if ((flags & PMEMFILE_O_CREAT) || is_tmpfile(flags))
-		mode = va_arg(ap, mode_t);
+		mode = va_arg(ap, pmemfile_mode_t);
 	va_end(ap);
 
 	return pmemfile_openat(pfp, PMEMFILE_AT_CWD, pathname, flags, mode);
 }
 
 PMEMfile *
-pmemfile_create(PMEMfilepool *pfp, const char *pathname, mode_t mode)
+pmemfile_create(PMEMfilepool *pfp, const char *pathname, pmemfile_mode_t mode)
 {
 	return pmemfile_open(pfp, pathname, PMEMFILE_O_CREAT |
 			PMEMFILE_O_WRONLY | PMEMFILE_O_TRUNC, mode);
@@ -1189,7 +1189,7 @@ pmemfile_symlink(PMEMfilepool *pfp, const char *target, const char *linkpath)
 	return pmemfile_symlinkat(pfp, target, PMEMFILE_AT_CWD, linkpath);
 }
 
-static ssize_t
+static pmemfile_ssize_t
 _pmemfile_readlinkat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 		const char *pathname, char *buf, size_t bufsiz)
 {
@@ -1198,7 +1198,7 @@ _pmemfile_readlinkat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 		return -1;
 
 	int error = 0;
-	ssize_t ret = -1;
+	pmemfile_ssize_t ret = -1;
 	struct pmemfile_vinode *vinode = NULL;
 	struct pmemfile_path_info info;
 	resolve_pathat(pfp, &cred, dir, pathname, &info, 0);
@@ -1234,7 +1234,7 @@ _pmemfile_readlinkat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 	if (len > bufsiz)
 		len = bufsiz;
 	memcpy(buf, data, len);
-	ret = (ssize_t)len;
+	ret = (pmemfile_ssize_t)len;
 
 	os_rwlock_unlock(&vinode->rwlock);
 
@@ -1253,7 +1253,7 @@ end:
 	return ret;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_readlinkat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 		char *buf, size_t bufsiz)
 {
@@ -1267,7 +1267,8 @@ pmemfile_readlinkat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 
 	at = pool_get_dir_for_path(pfp, dir, pathname, &at_unref);
 
-	ssize_t ret = _pmemfile_readlinkat(pfp, at, pathname, buf, bufsiz);
+	pmemfile_ssize_t ret =
+			_pmemfile_readlinkat(pfp, at, pathname, buf, bufsiz);
 
 	if (at_unref)
 		vinode_cleanup(pfp, at, ret < 0);
@@ -1275,7 +1276,7 @@ pmemfile_readlinkat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 	return ret;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_readlink(PMEMfilepool *pfp, const char *pathname, char *buf,
 		size_t bufsiz)
 {
@@ -1357,11 +1358,12 @@ pmemfile_stats(PMEMfilepool *pfp, struct pmemfile_stats *stats)
 }
 
 static int
-vinode_chmod(PMEMfilepool *pfp, struct pmemfile_vinode *vinode, mode_t mode)
+vinode_chmod(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
+		pmemfile_mode_t mode)
 {
 	struct pmemfile_inode *inode = vinode->inode;
 	int error = 0;
-	uid_t fsuid;
+	pmemfile_uid_t fsuid;
 	int cap;
 
 	os_rwlock_rdlock(&pfp->cred_rwlock);
@@ -1391,7 +1393,7 @@ vinode_chmod(PMEMfilepool *pfp, struct pmemfile_vinode *vinode, mode_t mode)
 
 static int
 _pmemfile_fchmodat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
-		const char *path, mode_t mode, int flags)
+		const char *path, pmemfile_mode_t mode, int flags)
 {
 	mode &= PMEMFILE_ALLPERMS;
 
@@ -1445,7 +1447,7 @@ end:
 
 int
 pmemfile_fchmodat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
-	mode_t mode, int flags)
+		pmemfile_mode_t mode, int flags)
 {
 	struct pmemfile_vinode *at;
 	bool at_unref;
@@ -1466,13 +1468,13 @@ pmemfile_fchmodat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 }
 
 int
-pmemfile_chmod(PMEMfilepool *pfp, const char *path, mode_t mode)
+pmemfile_chmod(PMEMfilepool *pfp, const char *path, pmemfile_mode_t mode)
 {
 	return pmemfile_fchmodat(pfp, PMEMFILE_AT_CWD, path, mode, 0);
 }
 
 int
-pmemfile_fchmod(PMEMfilepool *pfp, PMEMfile *file, mode_t mode)
+pmemfile_fchmod(PMEMfilepool *pfp, PMEMfile *file, pmemfile_mode_t mode)
 {
 	if (!file) {
 		errno = EBADF;
@@ -1495,22 +1497,22 @@ pmemfile_fchmod(PMEMfilepool *pfp, PMEMfile *file, mode_t mode)
 }
 
 int
-pmemfile_setreuid(PMEMfilepool *pfp, uid_t ruid, uid_t euid)
+pmemfile_setreuid(PMEMfilepool *pfp, pmemfile_uid_t ruid, pmemfile_uid_t euid)
 {
-	if (ruid != (uid_t)-1 && ruid > INT_MAX) {
+	if (ruid != (pmemfile_uid_t)-1 && ruid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	if (euid != (uid_t)-1 && euid > INT_MAX) {
+	if (euid != (pmemfile_uid_t)-1 && euid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
 	}
 
 	os_rwlock_wrlock(&pfp->cred_rwlock);
-	if (ruid != (uid_t)-1)
+	if (ruid != (pmemfile_uid_t)-1)
 		pfp->cred.ruid = ruid;
-	if (euid != (uid_t)-1) {
+	if (euid != (pmemfile_uid_t)-1) {
 		pfp->cred.euid = euid;
 		pfp->cred.fsuid = euid;
 	}
@@ -1520,22 +1522,22 @@ pmemfile_setreuid(PMEMfilepool *pfp, uid_t ruid, uid_t euid)
 }
 
 int
-pmemfile_setregid(PMEMfilepool *pfp, gid_t rgid, gid_t egid)
+pmemfile_setregid(PMEMfilepool *pfp, pmemfile_gid_t rgid, pmemfile_gid_t egid)
 {
-	if (rgid != (gid_t)-1 && rgid > INT_MAX) {
+	if (rgid != (pmemfile_gid_t)-1 && rgid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	if (egid != (gid_t)-1 && egid > INT_MAX) {
+	if (egid != (pmemfile_gid_t)-1 && egid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
 	}
 
 	os_rwlock_wrlock(&pfp->cred_rwlock);
-	if (rgid != (uid_t)-1)
+	if (rgid != (pmemfile_gid_t)-1)
 		pfp->cred.rgid = rgid;
-	if (egid != (uid_t)-1) {
+	if (egid != (pmemfile_gid_t)-1) {
 		pfp->cred.egid = egid;
 		pfp->cred.fsgid = egid;
 	}
@@ -1545,31 +1547,31 @@ pmemfile_setregid(PMEMfilepool *pfp, gid_t rgid, gid_t egid)
 }
 
 int
-pmemfile_setuid(PMEMfilepool *pfp, uid_t uid)
+pmemfile_setuid(PMEMfilepool *pfp, pmemfile_uid_t uid)
 {
-	return pmemfile_setreuid(pfp, (uid_t)-1, uid);
+	return pmemfile_setreuid(pfp, (pmemfile_uid_t)-1, uid);
 }
 
 int
-pmemfile_setgid(PMEMfilepool *pfp, gid_t gid)
+pmemfile_setgid(PMEMfilepool *pfp, pmemfile_gid_t gid)
 {
-	return pmemfile_setregid(pfp, (gid_t)-1, gid);
+	return pmemfile_setregid(pfp, (pmemfile_gid_t)-1, gid);
 }
 
-uid_t
+pmemfile_uid_t
 pmemfile_getuid(PMEMfilepool *pfp)
 {
-	uid_t ret;
+	pmemfile_uid_t ret;
 	os_rwlock_rdlock(&pfp->cred_rwlock);
 	ret = pfp->cred.ruid;
 	os_rwlock_unlock(&pfp->cred_rwlock);
 	return ret;
 }
 
-gid_t
+pmemfile_gid_t
 pmemfile_getgid(PMEMfilepool *pfp)
 {
-	gid_t ret;
+	pmemfile_gid_t ret;
 	os_rwlock_rdlock(&pfp->cred_rwlock);
 	ret = pfp->cred.rgid;
 	os_rwlock_unlock(&pfp->cred_rwlock);
@@ -1577,31 +1579,31 @@ pmemfile_getgid(PMEMfilepool *pfp)
 }
 
 int
-pmemfile_seteuid(PMEMfilepool *pfp, uid_t uid)
+pmemfile_seteuid(PMEMfilepool *pfp, pmemfile_uid_t uid)
 {
-	return pmemfile_setreuid(pfp, (uid_t)-1, uid);
+	return pmemfile_setreuid(pfp, (pmemfile_uid_t)-1, uid);
 }
 
 int
-pmemfile_setegid(PMEMfilepool *pfp, gid_t gid)
+pmemfile_setegid(PMEMfilepool *pfp, pmemfile_gid_t gid)
 {
-	return pmemfile_setregid(pfp, (gid_t)-1, gid);
+	return pmemfile_setregid(pfp, (pmemfile_gid_t)-1, gid);
 }
 
-uid_t
+pmemfile_uid_t
 pmemfile_geteuid(PMEMfilepool *pfp)
 {
-	uid_t ret;
+	pmemfile_uid_t ret;
 	os_rwlock_rdlock(&pfp->cred_rwlock);
 	ret = pfp->cred.euid;
 	os_rwlock_unlock(&pfp->cred_rwlock);
 	return ret;
 }
 
-gid_t
+pmemfile_gid_t
 pmemfile_getegid(PMEMfilepool *pfp)
 {
-	gid_t ret;
+	pmemfile_gid_t ret;
 	os_rwlock_rdlock(&pfp->cred_rwlock);
 	ret = pfp->cred.egid;
 	os_rwlock_unlock(&pfp->cred_rwlock);
@@ -1609,7 +1611,7 @@ pmemfile_getegid(PMEMfilepool *pfp)
 }
 
 int
-pmemfile_setfsuid(PMEMfilepool *pfp, uid_t fsuid)
+pmemfile_setfsuid(PMEMfilepool *pfp, pmemfile_uid_t fsuid)
 {
 	if (fsuid > INT_MAX) {
 		errno = EINVAL;
@@ -1617,7 +1619,7 @@ pmemfile_setfsuid(PMEMfilepool *pfp, uid_t fsuid)
 	}
 
 	os_rwlock_wrlock(&pfp->cred_rwlock);
-	uid_t prev_fsuid = pfp->cred.fsuid;
+	pmemfile_uid_t prev_fsuid = pfp->cred.fsuid;
 	pfp->cred.fsuid = fsuid;
 	os_rwlock_unlock(&pfp->cred_rwlock);
 
@@ -1625,7 +1627,7 @@ pmemfile_setfsuid(PMEMfilepool *pfp, uid_t fsuid)
 }
 
 int
-pmemfile_setfsgid(PMEMfilepool *pfp, uid_t fsgid)
+pmemfile_setfsgid(PMEMfilepool *pfp, pmemfile_gid_t fsgid)
 {
 	if (fsgid > INT_MAX) {
 		errno = EINVAL;
@@ -1633,7 +1635,7 @@ pmemfile_setfsgid(PMEMfilepool *pfp, uid_t fsgid)
 	}
 
 	os_rwlock_wrlock(&pfp->cred_rwlock);
-	uid_t prev_fsgid = pfp->cred.fsgid;
+	pmemfile_uid_t prev_fsgid = pfp->cred.fsgid;
 	pfp->cred.fsgid = fsgid;
 	os_rwlock_unlock(&pfp->cred_rwlock);
 
@@ -1641,7 +1643,7 @@ pmemfile_setfsgid(PMEMfilepool *pfp, uid_t fsgid)
 }
 
 int
-pmemfile_getgroups(PMEMfilepool *pfp, int size, gid_t list[])
+pmemfile_getgroups(PMEMfilepool *pfp, int size, pmemfile_gid_t list[])
 {
 	if (size < 0) {
 		errno = EINVAL;
@@ -1664,7 +1666,7 @@ pmemfile_getgroups(PMEMfilepool *pfp, int size, gid_t list[])
 }
 
 int
-pmemfile_setgroups(PMEMfilepool *pfp, size_t size, const gid_t *list)
+pmemfile_setgroups(PMEMfilepool *pfp, size_t size, const pmemfile_gid_t *list)
 {
 	int error = 0;
 	os_rwlock_wrlock(&pfp->cred_rwlock);
@@ -1717,7 +1719,7 @@ _pmemfile_ftruncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 }
 
 int
-pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, off_t length)
+pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t length)
 {
 	int ret;
 
@@ -1754,7 +1756,7 @@ pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, off_t length)
 }
 
 int
-pmemfile_truncate(PMEMfilepool *pfp, const char *path, off_t length)
+pmemfile_truncate(PMEMfilepool *pfp, const char *path, pmemfile_off_t length)
 {
 	if (length < 0) {
 		errno = EINVAL;
@@ -1826,7 +1828,8 @@ end:
  * Perform some checks that are independent of the file being operated on.
  */
 static int
-fallocate_check_arguments(int mode, off_t offset, off_t length)
+fallocate_check_arguments(int mode, pmemfile_off_t offset,
+		pmemfile_off_t length)
 {
 	/*
 	 * from man 2 fallocate:
@@ -1931,7 +1934,7 @@ file_fallocate(PMEMfilepool *pfp, PMEMfile *file, int mode,
 
 int
 pmemfile_fallocate(PMEMfilepool *pfp, PMEMfile *file, int mode,
-		off_t offset, off_t length)
+		pmemfile_off_t offset, pmemfile_off_t length)
 {
 	int error;
 
@@ -1959,19 +1962,20 @@ pmemfile_fallocate(PMEMfilepool *pfp, PMEMfile *file, int mode,
 
 int
 pmemfile_posix_fallocate(PMEMfilepool *pfp, PMEMfile *file,
-			off_t offset, off_t length)
+		pmemfile_off_t offset, pmemfile_off_t length)
 {
 	return pmemfile_fallocate(pfp, file, 0, offset, length);
 }
 
 static int
 vinode_chown(PMEMfilepool *pfp, struct pmemfile_cred *cred,
-		struct pmemfile_vinode *vinode, uid_t owner, gid_t group)
+		struct pmemfile_vinode *vinode, pmemfile_uid_t owner,
+		pmemfile_gid_t group)
 {
 	struct pmemfile_inode *inode = vinode->inode;
 	int error = 0;
 
-	if (owner == (uid_t)-1 && group == (gid_t)-1)
+	if (owner == (pmemfile_uid_t)-1 && group == (pmemfile_gid_t)-1)
 		return 0;
 
 	os_rwlock_wrlock(&vinode->rwlock);
@@ -1982,12 +1986,12 @@ vinode_chown(PMEMfilepool *pfp, struct pmemfile_cred *cred,
 			goto end;
 		}
 
-		if (owner != (uid_t)-1 && owner != inode->uid) {
+		if (owner != (pmemfile_uid_t)-1 && owner != inode->uid) {
 			error = EPERM;
 			goto end;
 		}
 
-		if (group != (gid_t)-1 && group != inode->gid) {
+		if (group != (pmemfile_gid_t)-1 && group != inode->gid) {
 			if (group != cred->fsgid && !gid_in_list(cred, group)) {
 				error = EPERM;
 				goto end;
@@ -2003,9 +2007,9 @@ vinode_chown(PMEMfilepool *pfp, struct pmemfile_cred *cred,
 		pmemobj_tx_add_range_direct(&inode->uid,
 				sizeof(inode->uid) + sizeof(inode->gid));
 
-		if (owner != (uid_t)-1)
+		if (owner != (pmemfile_uid_t)-1)
 			inode->uid = owner;
-		if (group != (gid_t)-1)
+		if (group != (pmemfile_gid_t)-1)
 			inode->gid = group;
 	} TX_ONABORT {
 		error = errno;
@@ -2019,7 +2023,8 @@ end:
 
 static int
 _pmemfile_fchownat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
-		const char *path, uid_t owner, gid_t group, int flags)
+		const char *path, pmemfile_uid_t owner, pmemfile_gid_t group,
+		int flags)
 {
 	if (flags & ~(PMEMFILE_AT_EMPTY_PATH | PMEMFILE_AT_SYMLINK_NOFOLLOW)) {
 		errno = EINVAL;
@@ -2072,7 +2077,7 @@ end:
 
 int
 pmemfile_fchownat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
-		uid_t owner, gid_t group, int flags)
+		pmemfile_uid_t owner, pmemfile_gid_t group, int flags)
 {
 	struct pmemfile_vinode *at;
 	bool at_unref;
@@ -2093,23 +2098,24 @@ pmemfile_fchownat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 }
 
 int
-pmemfile_chown(PMEMfilepool *pfp, const char *pathname, uid_t owner,
-		gid_t group)
+pmemfile_chown(PMEMfilepool *pfp, const char *pathname, pmemfile_uid_t owner,
+		pmemfile_gid_t group)
 {
 	return pmemfile_fchownat(pfp, PMEMFILE_AT_CWD, pathname, owner, group,
 			0);
 }
 
 int
-pmemfile_lchown(PMEMfilepool *pfp, const char *pathname, uid_t owner,
-		gid_t group)
+pmemfile_lchown(PMEMfilepool *pfp, const char *pathname, pmemfile_uid_t owner,
+		pmemfile_gid_t group)
 {
 	return pmemfile_fchownat(pfp, PMEMFILE_AT_CWD, pathname, owner, group,
 			PMEMFILE_AT_SYMLINK_NOFOLLOW);
 }
 
 int
-pmemfile_fchown(PMEMfilepool *pfp, PMEMfile *file, uid_t owner, gid_t group)
+pmemfile_fchown(PMEMfilepool *pfp, PMEMfile *file, pmemfile_uid_t owner,
+		pmemfile_gid_t group)
 {
 	if (!file) {
 		errno = EBADF;

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -636,14 +636,14 @@ vinode_stat(struct pmemfile_vinode *vinode, struct stat *buf)
 	buf->st_uid = inode->uid;
 	buf->st_gid = inode->gid;
 	buf->st_rdev = 0;
-	if ((off_t)inode->size < 0)
+	if ((pmemfile_off_t)inode->size < 0)
 		return EOVERFLOW;
-	buf->st_size = (off_t)inode->size;
+	buf->st_size = (pmemfile_off_t)inode->size;
 	buf->st_blksize = 1;
-	if ((blkcnt_t)inode->size < 0)
+	if ((pmemfile_blkcnt_t)inode->size < 0)
 		return EOVERFLOW;
 
-	blkcnt_t blks = 0;
+	pmemfile_blkcnt_t blks = 0;
 	if (inode_is_regular_file(inode)) {
 		const struct pmemfile_block_array *arr =
 				&inode->file_data.blocks;
@@ -658,7 +658,7 @@ vinode_stat(struct pmemfile_vinode *vinode, struct stat *buf)
 		 * XXX This doesn't match reality. It will match once we start
 		 * getting 4k-aligned blocks from pmemobj allocator.
 		 */
-		blks = (blkcnt_t)((sz + 511) / 512);
+		blks = (pmemfile_blkcnt_t)((sz + 511) / 512);
 	} else if (inode_is_dir(inode)) {
 		const struct pmemfile_dir *arr = &inode->file_data.dir;
 		size_t sz = 0;
@@ -671,7 +671,7 @@ vinode_stat(struct pmemfile_vinode *vinode, struct stat *buf)
 		 * XXX This doesn't match reality. It will match once we start
 		 * getting 4k-aligned blocks from pmemobj allocator.
 		 */
-		blks = (blkcnt_t)((sz + 511) / 512);
+		blks = (pmemfile_blkcnt_t)((sz + 511) / 512);
 	} else if (inode_is_symlink(inode)) {
 		blks = 0;
 	} else

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -470,7 +470,7 @@ vinode_unref_tx(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 void
 file_get_time(struct pmemfile_time *t)
 {
-	struct timespec tm;
+	pmemfile_timespec_t tm;
 	if (clock_gettime(CLOCK_REALTIME, &tm)) {
 		ERR("!clock_gettime");
 		pmemfile_tx_abort(errno);
@@ -611,10 +611,10 @@ inode_free(PMEMfilepool *pfp, TOID(struct pmemfile_inode) tinode)
 /*
  * pmemfile_time_to_timespec -- convert between pmemfile_time and timespec
  */
-static inline struct timespec
+static inline pmemfile_timespec_t
 pmemfile_time_to_timespec(const struct pmemfile_time *t)
 {
-	struct timespec tm;
+	pmemfile_timespec_t tm;
 	tm.tv_sec = t->sec;
 	tm.tv_nsec = t->nsec;
 	return tm;
@@ -624,7 +624,7 @@ pmemfile_time_to_timespec(const struct pmemfile_time *t)
  * vinode_stat -- fill struct stat using information from vinode
  */
 static int
-vinode_stat(struct pmemfile_vinode *vinode, struct stat *buf)
+vinode_stat(struct pmemfile_vinode *vinode, pmemfile_stat_t *buf)
 {
 	struct pmemfile_inode *inode = vinode->inode;
 
@@ -686,7 +686,7 @@ vinode_stat(struct pmemfile_vinode *vinode, struct stat *buf)
 
 static int
 _pmemfile_fstatat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
-		const char *path, struct stat *buf, int flags)
+		const char *path, pmemfile_stat_t *buf, int flags)
 {
 	int error = 0;
 	struct pmemfile_cred cred;
@@ -748,7 +748,7 @@ ret:
 
 int
 pmemfile_fstatat(PMEMfilepool *pfp, PMEMfile *dir, const char *path,
-		struct stat *buf, int flags)
+		pmemfile_stat_t *buf, int flags)
 {
 	struct pmemfile_vinode *at;
 	bool at_unref;
@@ -772,7 +772,7 @@ pmemfile_fstatat(PMEMfilepool *pfp, PMEMfile *dir, const char *path,
  * pmemfile_stat
  */
 int
-pmemfile_stat(PMEMfilepool *pfp, const char *path, struct stat *buf)
+pmemfile_stat(PMEMfilepool *pfp, const char *path, pmemfile_stat_t *buf)
 {
 	return pmemfile_fstatat(pfp, PMEMFILE_AT_CWD, path, buf, 0);
 }
@@ -781,7 +781,7 @@ pmemfile_stat(PMEMfilepool *pfp, const char *path, struct stat *buf)
  * pmemfile_fstat
  */
 int
-pmemfile_fstat(PMEMfilepool *pfp, PMEMfile *file, struct stat *buf)
+pmemfile_fstat(PMEMfilepool *pfp, PMEMfile *file, pmemfile_stat_t *buf)
 {
 	if (!file) {
 		errno = EBADF;
@@ -807,7 +807,7 @@ pmemfile_fstat(PMEMfilepool *pfp, PMEMfile *file, struct stat *buf)
  * pmemfile_lstat
  */
 int
-pmemfile_lstat(PMEMfilepool *pfp, const char *path, struct stat *buf)
+pmemfile_lstat(PMEMfilepool *pfp, const char *path, pmemfile_stat_t *buf)
 {
 	return pmemfile_fstatat(pfp, PMEMFILE_AT_CWD, path, buf,
 			PMEMFILE_AT_SYMLINK_NOFOLLOW);

--- a/src/libpmemfile-posix/libpmemfile-posix.map
+++ b/src/libpmemfile-posix/libpmemfile-posix.map
@@ -74,7 +74,6 @@
 		pmemfile_link;
 		pmemfile_linkat;
 		pmemfile_lseek;
-		pmemfile_lseek64;
 		pmemfile_lstat;
 		pmemfile_lstat;
 		pmemfile_lutimes;

--- a/src/libpmemfile-posix/pool.c
+++ b/src/libpmemfile-posix/pool.c
@@ -191,7 +191,7 @@ cleanup_orphanded_inodes(PMEMfilepool *pfp,
  * pmemfile_mkfs -- create pmem file system on specified file
  */
 PMEMfilepool *
-pmemfile_mkfs(const char *pathname, size_t poolsize, mode_t mode)
+pmemfile_mkfs(const char *pathname, size_t poolsize, pmemfile_mode_t mode)
 {
 	LOG(LDBG, "pathname %s poolsize %zu mode %o", pathname, poolsize, mode);
 
@@ -308,7 +308,7 @@ pmemfile_pool_close(PMEMfilepool *pfp)
  * gid_in_list -- return true when gid is in supplementary groups list
  */
 bool
-gid_in_list(const struct pmemfile_cred *cred, gid_t gid)
+gid_in_list(const struct pmemfile_cred *cred, pmemfile_gid_t gid)
 {
 	for (size_t i = 0; i < cred->groupsnum; ++i) {
 		if (cred->groups[i] == gid)
@@ -325,10 +325,10 @@ gid_in_list(const struct pmemfile_cred *cred, gid_t gid)
 bool
 can_access(const struct pmemfile_cred *cred, struct inode_perms perms, int acc)
 {
-	mode_t perm = perms.flags & PMEMFILE_ACCESSPERMS;
-	mode_t req = 0;
-	uid_t uid;
-	gid_t gid;
+	pmemfile_mode_t perm = perms.flags & PMEMFILE_ACCESSPERMS;
+	pmemfile_mode_t req = 0;
+	pmemfile_uid_t uid;
+	pmemfile_gid_t gid;
 	int acctype = acc & PFILE_ACCESS_MASK;
 
 	if (acctype == PFILE_USE_FACCESS) {

--- a/src/libpmemfile-posix/pool.h
+++ b/src/libpmemfile-posix/pool.h
@@ -44,22 +44,22 @@ struct pmemfile_inode_map;
 
 struct pmemfile_cred {
 	/* real user id */
-	uid_t ruid;
+	pmemfile_uid_t ruid;
 	/* real group id */
-	gid_t rgid;
+	pmemfile_gid_t rgid;
 
 	/* effective user id */
-	uid_t euid;
+	pmemfile_uid_t euid;
 	/* effective group id */
-	gid_t egid;
+	pmemfile_gid_t egid;
 
 	/* filesystem user id */
-	uid_t fsuid;
+	pmemfile_uid_t fsuid;
 	/* filesystem group id */
-	gid_t fsgid;
+	pmemfile_gid_t fsgid;
 
 	/* supplementary group IDs */
-	gid_t *groups;
+	pmemfile_gid_t *groups;
 	size_t groupsnum;
 
 	/* capabilities */
@@ -111,6 +111,6 @@ bool vinode_can_access(const struct pmemfile_cred *cred,
 bool _vinode_can_access(const struct pmemfile_cred *cred,
 		struct pmemfile_vinode *vinode, int acc);
 
-bool gid_in_list(const struct pmemfile_cred *cred, gid_t gid);
+bool gid_in_list(const struct pmemfile_cred *cred, pmemfile_gid_t gid);
 
 #endif

--- a/src/libpmemfile-posix/stubs.c
+++ b/src/libpmemfile-posix/stubs.c
@@ -161,8 +161,8 @@ pmemfile_mprotect(PMEMfilepool *pfp, void *addr, size_t len, int prot)
 }
 
 pmemfile_ssize_t
-pmemfile_readv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
-	int iovcnt)
+pmemfile_readv(PMEMfilepool *pfp, PMEMfile *file,
+		const pmemfile_iovec_t *iov, int iovcnt)
 {
 	check_pfp(pfp);
 
@@ -175,8 +175,8 @@ pmemfile_readv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 }
 
 pmemfile_ssize_t
-pmemfile_writev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
-	int iovcnt)
+pmemfile_writev(PMEMfilepool *pfp, PMEMfile *file,
+		const pmemfile_iovec_t *iov, int iovcnt)
 {
 	check_pfp(pfp);
 
@@ -189,8 +189,9 @@ pmemfile_writev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 }
 
 pmemfile_ssize_t
-pmemfile_preadv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
-	int iovcnt, pmemfile_off_t offset)
+pmemfile_preadv(PMEMfilepool *pfp, PMEMfile *file,
+		const pmemfile_iovec_t *iov, int iovcnt,
+		pmemfile_off_t offset)
 {
 	check_pfp(pfp);
 
@@ -204,8 +205,9 @@ pmemfile_preadv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 }
 
 pmemfile_ssize_t
-pmemfile_pwritev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
-	int iovcnt, pmemfile_off_t offset)
+pmemfile_pwritev(PMEMfilepool *pfp, PMEMfile *file,
+		const pmemfile_iovec_t *iov, int iovcnt,
+		pmemfile_off_t offset)
 {
 	check_pfp(pfp);
 
@@ -220,7 +222,7 @@ pmemfile_pwritev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 
 int
 pmemfile_utime(PMEMfilepool *pfp, const char *filename,
-		const struct utimbuf *times)
+		const pmemfile_utimbuf_t *times)
 {
 	check_pfp(pfp);
 
@@ -233,7 +235,7 @@ pmemfile_utime(PMEMfilepool *pfp, const char *filename,
 
 int
 pmemfile_utimes(PMEMfilepool *pfp, const char *filename,
-		const struct timeval times[2])
+		const pmemfile_timeval_t times[2])
 {
 	check_pfp(pfp);
 
@@ -246,7 +248,7 @@ pmemfile_utimes(PMEMfilepool *pfp, const char *filename,
 
 int
 pmemfile_futimes(PMEMfilepool *pfp, PMEMfile *file,
-		const struct timeval tv[2])
+		const pmemfile_timeval_t tv[2])
 {
 	check_pfp(pfp);
 
@@ -259,7 +261,7 @@ pmemfile_futimes(PMEMfilepool *pfp, PMEMfile *file,
 
 int
 pmemfile_lutimes(PMEMfilepool *pfp, const char *filename,
-		const struct timeval tv[2])
+		const pmemfile_timeval_t tv[2])
 {
 	check_pfp(pfp);
 
@@ -272,7 +274,7 @@ pmemfile_lutimes(PMEMfilepool *pfp, const char *filename,
 
 int
 pmemfile_utimensat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
-		const struct timespec times[2], int flags)
+		const pmemfile_timespec_t times[2], int flags)
 {
 	check_pfp(pfp);
 
@@ -287,7 +289,7 @@ pmemfile_utimensat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 
 int
 pmemfile_futimens(PMEMfilepool *pfp, PMEMfile *file,
-		const struct timespec times[2])
+		const pmemfile_timespec_t times[2])
 {
 	check_pfp(pfp);
 

--- a/src/libpmemfile-posix/stubs.c
+++ b/src/libpmemfile-posix/stubs.c
@@ -92,7 +92,7 @@ pmemfile_dup2(PMEMfilepool *pfp, PMEMfile *file, PMEMfile *file2)
 
 void *
 pmemfile_mmap(PMEMfilepool *pfp, void *addr, size_t len,
-		int prot, int flags, PMEMfile *file, off_t off)
+		int prot, int flags, PMEMfile *file, pmemfile_off_t off)
 {
 	check_pfp_file(pfp, file);
 
@@ -160,7 +160,7 @@ pmemfile_mprotect(PMEMfilepool *pfp, void *addr, size_t len, int prot)
 	return -1;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_readv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 	int iovcnt)
 {
@@ -174,7 +174,7 @@ pmemfile_readv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 	return -1;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_writev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 	int iovcnt)
 {
@@ -188,9 +188,9 @@ pmemfile_writev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 	return -1;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_preadv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
-	int iovcnt, off_t offset)
+	int iovcnt, pmemfile_off_t offset)
 {
 	check_pfp(pfp);
 
@@ -203,9 +203,9 @@ pmemfile_preadv(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
 	return -1;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_pwritev(PMEMfilepool *pfp, PMEMfile *file, const struct iovec *iov,
-	int iovcnt, off_t offset)
+	int iovcnt, pmemfile_off_t offset)
 {
 	check_pfp(pfp);
 
@@ -298,8 +298,8 @@ pmemfile_futimens(PMEMfilepool *pfp, PMEMfile *file,
 	return -1;
 }
 
-mode_t
-pmemfile_umask(PMEMfilepool *pfp, mode_t mask)
+pmemfile_mode_t
+pmemfile_umask(PMEMfilepool *pfp, pmemfile_mode_t mask)
 {
 	check_pfp(pfp);
 
@@ -308,10 +308,10 @@ pmemfile_umask(PMEMfilepool *pfp, mode_t mask)
 	return 0;
 }
 
-ssize_t
+pmemfile_ssize_t
 pmemfile_copy_file_range(PMEMfilepool *pfp,
-		PMEMfile *file_in, loff_t *off_in,
-		PMEMfile *file_out, loff_t *off_out,
+		PMEMfile *file_in, pmemfile_off_t *off_in,
+		PMEMfile *file_out, pmemfile_off_t *off_out,
 		size_t len, unsigned flags)
 {
 	check_pfp(pfp);

--- a/src/libpmemfile/path_resolve.c
+++ b/src/libpmemfile/path_resolve.c
@@ -69,7 +69,7 @@ get_stat(struct resolved_path *result, struct stat *buf)
 		int r = pmemfile_fstatat(result->at.pmem_fda.pool->pool,
 			result->at.pmem_fda.file,
 			result->path,
-			buf,
+			(pmemfile_stat_t *)buf,
 			AT_SYMLINK_NOFOLLOW);
 
 		if (r == 0) {

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -1338,7 +1338,7 @@ hook_newfstatat(struct fd_desc at, long arg0, long arg1, long arg2)
 	int r = pmemfile_fstatat(where.at.pmem_fda.pool->pool,
 	    where.at.pmem_fda.file,
 	    where.path,
-	    (struct stat *)arg1, (int)arg2);
+		(pmemfile_stat_t *)arg1, (int)arg2);
 
 	if (r != 0)
 		r = -errno;
@@ -1351,7 +1351,7 @@ hook_fstat(long fd, long buf_addr)
 {
 	struct fd_association *file = fd_table + fd;
 	long r = pmemfile_fstat(file->pool->pool, file->file,
-	    (struct stat *)buf_addr);
+			(pmemfile_stat_t *)buf_addr);
 
 	if (r < 0)
 		r = -errno;
@@ -1410,7 +1410,7 @@ hook_faccessat(struct fd_desc at, long path_arg, long mode, long flags)
 		    where.at.kernel_fd, where.path, mode, flags);
 	}
 
-	struct stat stat;
+	pmemfile_stat_t stat;
 	/* XXX implement for real! */
 	if (pmemfile_fstatat(where.at.pmem_fda.pool->pool,
 			where.at.pmem_fda.file, where.path, &stat, 0))

--- a/src/tools/pmemfile-cat.c
+++ b/src/tools/pmemfile-cat.c
@@ -57,7 +57,7 @@ static void
 dump_file(PMEMfilepool *pool, const char *path)
 {
 	char buffer[0x10000];
-	ssize_t read_size;
+	pmemfile_ssize_t read_size;
 
 	errno = 0;
 

--- a/tests/posix/basic/basic.cpp
+++ b/tests/posix/basic/basic.cpp
@@ -378,7 +378,7 @@ TEST_F(basic, unlink)
 
 TEST_F(basic, tmpfile)
 {
-	ssize_t written;
+	pmemfile_ssize_t written;
 
 	PMEMfile *f = pmemfile_open(
 		pfp, "/", PMEMFILE_O_TMPFILE | PMEMFILE_O_WRONLY, 0644);

--- a/tests/posix/dirs/dirs.cpp
+++ b/tests/posix/dirs/dirs.cpp
@@ -208,7 +208,7 @@ TEST_F(dirs, lots_of_files)
 	int ret;
 	PMEMfile *f;
 	char buf[1001];
-	ssize_t written;
+	pmemfile_ssize_t written;
 
 	ASSERT_TRUE(test_empty_dir(pfp, "/"));
 	memset(buf, 0xff, sizeof(buf));
@@ -222,7 +222,7 @@ TEST_F(dirs, lots_of_files)
 		ASSERT_NE(f, nullptr) << strerror(errno);
 
 		written = pmemfile_write(pfp, f, buf, i);
-		ASSERT_EQ(written, (ssize_t)i) << COND_ERROR(written);
+		ASSERT_EQ(written, (pmemfile_ssize_t)i) << COND_ERROR(written);
 
 		pmemfile_close(pfp, f);
 
@@ -700,7 +700,7 @@ TEST_F(dirs, file_renames)
 }
 
 static bool
-is_owned(PMEMfilepool *pfp, const char *path, uid_t owner)
+is_owned(PMEMfilepool *pfp, const char *path, pmemfile_uid_t owner)
 {
 	struct stat st;
 	memset(&st, 0xff, sizeof(st));
@@ -843,7 +843,8 @@ TEST_F(dirs, openat)
 }
 
 static bool
-test_file_info(PMEMfilepool *pfp, const char *path, nlink_t nlink, ino_t ino)
+test_file_info(PMEMfilepool *pfp, const char *path, pmemfile_nlink_t nlink,
+	       pmemfile_ino_t ino)
 {
 	struct stat st;
 	memset(&st, 0, sizeof(st));
@@ -1076,7 +1077,8 @@ TEST_F(dirs, O_PATH)
 	ASSERT_EQ(pmemfile_symlinkat(pfp, "/file1", dir, "fileXXX"), -1);
 	EXPECT_EQ(errno, EACCES);
 
-	ssize_t r = pmemfile_readlinkat(pfp, dir, "symlink", buf, sizeof(buf));
+	pmemfile_ssize_t r =
+		pmemfile_readlinkat(pfp, dir, "symlink", buf, sizeof(buf));
 	EXPECT_GT(r, 0);
 	if (r > 0)
 		EXPECT_EQ((size_t)r, strlen("/dir/file"));

--- a/tests/posix/getdents/getdents.cpp
+++ b/tests/posix/getdents/getdents.cpp
@@ -160,7 +160,7 @@ TEST_F(getdents, 1)
 	r = pmemfile_getdents(pfp, f, dirents, sizeof(buf));
 	ASSERT_EQ(r, 0);
 
-	off_t off = pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_SET);
+	pmemfile_off_t off = pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_SET);
 	ASSERT_EQ(off, 0);
 
 	r = pmemfile_getdents64(pfp, f, dirents64, sizeof(buf));

--- a/tests/posix/permissions/permissions.cpp
+++ b/tests/posix/permissions/permissions.cpp
@@ -54,8 +54,8 @@ TEST_F(permissions, chmod)
 						 PMEMFILE_S_IROTH));
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
-			   PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
+				    PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
 
 	errno = 0;
 	ASSERT_EQ(pmemfile_chmod(pfp, "/a_not_exists",
@@ -73,12 +73,14 @@ TEST_F(permissions, chmod)
 
 		/* chmod u+rw */
 		ASSERT_EQ(pmemfile_chmod(pfp, "/aaa", PMEMFILE_S_IRUSR |
-						 PMEMFILE_S_IWUSR | (mode_t)m),
+						 PMEMFILE_S_IWUSR |
+						 (pmemfile_mode_t)m),
 			  0)
 			<< strerror(errno);
 		ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 		EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-			  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR | m));
+			  (pmemfile_mode_t)(PMEMFILE_S_IRUSR |
+					    PMEMFILE_S_IWUSR | m));
 
 		/* open rw */
 		f = pmemfile_open(pfp, "/aaa", PMEMFILE_O_RDWR);
@@ -102,12 +104,12 @@ TEST_F(permissions, chmod)
 
 		/* chmod u+r */
 		ASSERT_EQ(pmemfile_chmod(pfp, "/aaa",
-					 PMEMFILE_S_IRUSR | (mode_t)m),
+					 PMEMFILE_S_IRUSR | (pmemfile_mode_t)m),
 			  0)
 			<< strerror(errno);
 		ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 		EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-			  (mode_t)(PMEMFILE_S_IRUSR | m));
+			  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | m));
 
 		/* open rw */
 		errno = 0;
@@ -133,12 +135,12 @@ TEST_F(permissions, chmod)
 
 		/* chmod u+w */
 		ASSERT_EQ(pmemfile_chmod(pfp, "/aaa",
-					 PMEMFILE_S_IWUSR | (mode_t)m),
+					 PMEMFILE_S_IWUSR | (pmemfile_mode_t)m),
 			  0)
 			<< strerror(errno);
 		ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 		EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-			  (mode_t)(PMEMFILE_S_IWUSR | m));
+			  (pmemfile_mode_t)(PMEMFILE_S_IWUSR | m));
 
 		/* open rw */
 		errno = 0;
@@ -173,13 +175,13 @@ TEST_F(permissions, symlink)
 
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
-			   PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
+				    PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
 
 	ASSERT_EQ(pmemfile_lstat(pfp, "/bbb", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRWXU | PMEMFILE_S_IRWXG |
-			   PMEMFILE_S_IRWXO));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRWXU | PMEMFILE_S_IRWXG |
+				    PMEMFILE_S_IRWXO));
 
 	ASSERT_EQ(pmemfile_chmod(pfp, "/bbb",
 				 PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR),
@@ -187,24 +189,24 @@ TEST_F(permissions, symlink)
 
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR));
 
 	ASSERT_EQ(pmemfile_lstat(pfp, "/bbb", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRWXU | PMEMFILE_S_IRWXG |
-			   PMEMFILE_S_IRWXO));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRWXU | PMEMFILE_S_IRWXG |
+				    PMEMFILE_S_IRWXO));
 
 	ASSERT_EQ(pmemfile_unlink(pfp, "/aaa"), 0);
 	ASSERT_EQ(pmemfile_unlink(pfp, "/bbb"), 0);
 }
 
-#define TEST_EUID ((uid_t)1000)
-#define TEST_EGID ((uid_t)2000)
+#define TEST_EUID ((pmemfile_uid_t)1000)
+#define TEST_EGID ((pmemfile_uid_t)2000)
 
-#define TEST_FSUID ((uid_t)5000)
-#define TEST_FSGID ((gid_t)6000)
+#define TEST_FSUID ((pmemfile_uid_t)5000)
+#define TEST_FSGID ((pmemfile_gid_t)6000)
 
-#define TEST_SUPP_GID ((uid_t)3000)
+#define TEST_SUPP_GID ((pmemfile_uid_t)3000)
 
 TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 {
@@ -218,19 +220,19 @@ TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 
 	prev_uid = pmemfile_setfsuid(pfp, TEST_FSUID);
 	ASSERT_GE(prev_uid, 0) << strerror(errno);
-	ASSERT_EQ((uid_t)prev_uid, TEST_EUID);
+	ASSERT_EQ((pmemfile_uid_t)prev_uid, TEST_EUID);
 
 	prev_gid = pmemfile_setfsgid(pfp, TEST_FSGID);
 	ASSERT_GE(prev_gid, 0) << strerror(errno);
-	ASSERT_EQ((uid_t)prev_gid, TEST_EGID);
+	ASSERT_EQ((pmemfile_uid_t)prev_gid, TEST_EGID);
 
 	prev_uid = pmemfile_setfsuid(pfp, TEST_EUID);
 	ASSERT_GE(prev_uid, 0) << strerror(errno);
-	ASSERT_EQ((uid_t)prev_uid, TEST_FSUID);
+	ASSERT_EQ((pmemfile_uid_t)prev_uid, TEST_FSUID);
 
 	prev_gid = pmemfile_setfsgid(pfp, TEST_EGID);
 	ASSERT_GE(prev_gid, 0) << strerror(errno);
-	ASSERT_EQ((uid_t)prev_gid, TEST_FSGID);
+	ASSERT_EQ((pmemfile_uid_t)prev_gid, TEST_FSGID);
 
 	ASSERT_TRUE(test_pmemfile_create(
 		pfp, "/aaa", PMEMFILE_O_EXCL, PMEMFILE_S_IRUSR |
@@ -239,11 +241,11 @@ TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 
 	prev_uid = pmemfile_setfsuid(pfp, TEST_FSUID);
 	ASSERT_GE(prev_uid, 0) << strerror(errno);
-	ASSERT_EQ((uid_t)prev_uid, TEST_EUID);
+	ASSERT_EQ((pmemfile_uid_t)prev_uid, TEST_EUID);
 
 	prev_gid = pmemfile_setfsgid(pfp, TEST_FSGID);
 	ASSERT_GE(prev_gid, 0) << strerror(errno);
-	ASSERT_EQ((uid_t)prev_gid, TEST_EGID);
+	ASSERT_EQ((pmemfile_uid_t)prev_gid, TEST_EGID);
 
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_uid, TEST_EUID);
@@ -266,14 +268,14 @@ TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 	f = pmemfile_open(pfp, "/aaa", PMEMFILE_O_WRONLY);
 	ASSERT_EQ(f, nullptr);
 
-	gid_t l0[1] = {TEST_SUPP_GID};
+	pmemfile_gid_t l0[1] = {TEST_SUPP_GID};
 	ASSERT_EQ(pmemfile_setgroups(pfp, 1, l0), 0) << strerror(errno);
 
 	/* open rw */
 	f = pmemfile_open(pfp, "/aaa", PMEMFILE_O_RDWR);
 	ASSERT_EQ(f, nullptr);
 
-	gid_t l1[2] = {TEST_EGID, TEST_SUPP_GID};
+	pmemfile_gid_t l1[2] = {TEST_EGID, TEST_SUPP_GID};
 	ASSERT_EQ(pmemfile_setgroups(pfp, 2, l1), 0) << strerror(errno);
 
 	/* open rw */
@@ -281,7 +283,7 @@ TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 	ASSERT_NE(f, nullptr) << strerror(errno);
 	pmemfile_close(pfp, f);
 
-	gid_t l2[2] = {0, 0};
+	pmemfile_gid_t l2[2] = {0, 0};
 	errno = 0;
 	ASSERT_EQ(pmemfile_getgroups(pfp, 0, l2), -1);
 	EXPECT_EQ(errno, EINVAL);
@@ -290,8 +292,8 @@ TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 	ASSERT_EQ(pmemfile_getgroups(pfp, 1, l2), -1);
 	EXPECT_EQ(errno, EINVAL);
 
-	EXPECT_EQ(l2[0], (gid_t)0);
-	EXPECT_EQ(l2[1], (gid_t)0);
+	EXPECT_EQ(l2[0], (pmemfile_gid_t)0);
+	EXPECT_EQ(l2[1], (pmemfile_gid_t)0);
 
 	ASSERT_EQ(pmemfile_getgroups(pfp, 2, l2), 2);
 	EXPECT_EQ(l2[0], TEST_EGID);
@@ -339,8 +341,8 @@ TEST_F(permissions, fchmod)
 						 PMEMFILE_S_IROTH));
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
-			   PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
+				    PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
 
 	f = pmemfile_open(pfp, "/aaa", PMEMFILE_O_RDONLY);
 	ASSERT_NE(f, nullptr) << strerror(errno);
@@ -353,17 +355,17 @@ TEST_F(permissions, fchmod)
 	memset(&statbuf, 0, sizeof(statbuf));
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
-			   PMEMFILE_S_IRGRP | PMEMFILE_S_IWGRP |
-			   PMEMFILE_S_IROTH));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
+				    PMEMFILE_S_IRGRP | PMEMFILE_S_IWGRP |
+				    PMEMFILE_S_IROTH));
 	pmemfile_close(pfp, f);
 
 	memset(&statbuf, 0, sizeof(statbuf));
 	ASSERT_EQ(pmemfile_stat(pfp, "/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
-			   PMEMFILE_S_IRGRP | PMEMFILE_S_IWGRP |
-			   PMEMFILE_S_IROTH));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
+				    PMEMFILE_S_IRGRP | PMEMFILE_S_IWGRP |
+				    PMEMFILE_S_IROTH));
 
 	ASSERT_EQ(pmemfile_unlink(pfp, "/aaa"), 0);
 }
@@ -381,8 +383,8 @@ TEST_F(permissions, fchmodat)
 						 PMEMFILE_S_IROTH));
 	ASSERT_EQ(pmemfile_stat(pfp, "/dir/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
-			   PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
+		  (pmemfile_mode_t)(PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
+				    PMEMFILE_S_IRGRP | PMEMFILE_S_IROTH));
 
 	dir = pmemfile_open(pfp, "/dir", PMEMFILE_O_DIRECTORY);
 	ASSERT_NE(dir, nullptr) << strerror(errno);
@@ -398,7 +400,7 @@ TEST_F(permissions, fchmodat)
 
 	ASSERT_EQ(pmemfile_stat(pfp, "/dir/aaa", &statbuf), 0);
 	EXPECT_EQ(statbuf.st_mode & PMEMFILE_ALLPERMS,
-		  (mode_t)PMEMFILE_ACCESSPERMS);
+		  (pmemfile_mode_t)PMEMFILE_ACCESSPERMS);
 
 	pmemfile_close(pfp, dir);
 	ASSERT_EQ(pmemfile_unlink(pfp, "/dir/aaa"), 0);
@@ -878,8 +880,8 @@ TEST_F(permissions, rename)
 }
 
 static bool
-test_chown(PMEMfilepool *pfp, const char *pathname, uid_t owner, gid_t group,
-	   int error)
+test_chown(PMEMfilepool *pfp, const char *pathname, pmemfile_uid_t owner,
+	   pmemfile_gid_t group, int error)
 {
 	int r = pmemfile_chown(pfp, pathname, owner, group);
 	if (error) {
@@ -899,13 +901,13 @@ test_chown(PMEMfilepool *pfp, const char *pathname, uid_t owner, gid_t group,
 			return false;
 		}
 
-		if (owner != (uid_t)-1) {
+		if (owner != (pmemfile_uid_t)-1) {
 			EXPECT_EQ(s.st_uid, owner);
 			if (s.st_uid != owner)
 				return false;
 		}
 
-		if (group != (gid_t)-1) {
+		if (group != (pmemfile_gid_t)-1) {
 			EXPECT_EQ(s.st_gid, group);
 			if (s.st_gid != group)
 				return false;
@@ -927,14 +929,15 @@ TEST_F(permissions, chown)
 	/* ruid=euid=fsuid=0, rgid=egid=fsgid=0 */
 
 	ASSERT_TRUE(test_chown(pfp, "/file", 0, 0, 0));
-	ASSERT_TRUE(test_chown(pfp, "/file", (uid_t)-1, 0, 0));
-	ASSERT_TRUE(test_chown(pfp, "/file", 0, (gid_t)-1, 0));
-	ASSERT_TRUE(test_chown(pfp, "/file", (uid_t)-1, (gid_t)-1, 0));
+	ASSERT_TRUE(test_chown(pfp, "/file", (pmemfile_uid_t)-1, 0, 0));
+	ASSERT_TRUE(test_chown(pfp, "/file", 0, (pmemfile_gid_t)-1, 0));
+	ASSERT_TRUE(test_chown(pfp, "/file", (pmemfile_uid_t)-1,
+			       (pmemfile_gid_t)-1, 0));
 
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 0, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 0, 1001, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1001, EPERM));
-	ASSERT_TRUE(test_chown(pfp, "/file", (uid_t)-1, 1001, EPERM));
+	ASSERT_TRUE(test_chown(pfp, "/file", (pmemfile_uid_t)-1, 1001, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1002, EPERM));
 
 	ASSERT_EQ(pmemfile_setreuid(pfp, 1000, 1000), 0);
@@ -953,7 +956,7 @@ TEST_F(permissions, chown)
 	ASSERT_TRUE(test_chown(pfp, "/file", 0, 1001, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1000, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1001, EPERM));
-	ASSERT_TRUE(test_chown(pfp, "/file", (uid_t)-1, 1001, EPERM));
+	ASSERT_TRUE(test_chown(pfp, "/file", (pmemfile_uid_t)-1, 1001, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1002, EPERM));
 
 	ASSERT_EQ(pmemfile_setfsgid(pfp, 1001), 0);
@@ -964,10 +967,10 @@ TEST_F(permissions, chown)
 	ASSERT_TRUE(test_chown(pfp, "/file", 0, 1001, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1000, EPERM));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1001, 0));
-	ASSERT_TRUE(test_chown(pfp, "/file", (uid_t)-1, 1001, 0));
+	ASSERT_TRUE(test_chown(pfp, "/file", (pmemfile_uid_t)-1, 1001, 0));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1002, EPERM));
 
-	gid_t groups[1] = {1002};
+	pmemfile_gid_t groups[1] = {1002};
 	ASSERT_EQ(pmemfile_setgroups(pfp, 1, groups), 0);
 
 	/* ruid=euid=fsuid=1000, rgid=egid=0, fsgid=1001, gids=1002 */
@@ -976,30 +979,30 @@ TEST_F(permissions, chown)
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1002, 0));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1001, 0));
 	ASSERT_TRUE(test_chown(pfp, "/file", 1000, 1000, EPERM));
-	ASSERT_TRUE(test_chown(pfp, "/file0", (uid_t)-1, 1001, EPERM));
-	ASSERT_TRUE(test_chown(pfp, "/file0", (uid_t)-1, 1002, EPERM));
+	ASSERT_TRUE(test_chown(pfp, "/file0", (pmemfile_uid_t)-1, 1001, EPERM));
+	ASSERT_TRUE(test_chown(pfp, "/file0", (pmemfile_uid_t)-1, 1002, EPERM));
 
 	ASSERT_EQ(pmemfile_symlink(pfp, "/file", "/symlink"), 0)
 		<< strerror(errno);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_stat(pfp, "/file", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)1001);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)1001);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_lstat(pfp, "/symlink", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)0);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)0);
 
-	ASSERT_EQ(pmemfile_chown(pfp, "/symlink", (uid_t)-1, 1002), 0)
+	ASSERT_EQ(pmemfile_chown(pfp, "/symlink", (pmemfile_uid_t)-1, 1002), 0)
 		<< strerror(errno);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_stat(pfp, "/file", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)1002);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)1002);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_lstat(pfp, "/symlink", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)0);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)0);
 
 	ASSERT_EQ(pmemfile_unlink(pfp, "/symlink"), 0);
 	ASSERT_EQ(pmemfile_unlink(pfp, "/file"), 0);
@@ -1007,7 +1010,8 @@ TEST_F(permissions, chown)
 }
 
 static bool
-test_fchown(PMEMfilepool *pfp, PMEMfile *f, uid_t owner, gid_t group, int error)
+test_fchown(PMEMfilepool *pfp, PMEMfile *f, pmemfile_uid_t owner,
+	    pmemfile_gid_t group, int error)
 {
 	int r = pmemfile_fchown(pfp, f, owner, group);
 	if (error) {
@@ -1027,13 +1031,13 @@ test_fchown(PMEMfilepool *pfp, PMEMfile *f, uid_t owner, gid_t group, int error)
 			return false;
 		}
 
-		if (owner != (uid_t)-1) {
+		if (owner != (pmemfile_uid_t)-1) {
 			EXPECT_EQ(s.st_uid, owner);
 			if (s.st_uid != owner)
 				return false;
 		}
 
-		if (group != (gid_t)-1) {
+		if (group != (pmemfile_gid_t)-1) {
 			EXPECT_EQ(s.st_gid, group);
 			if (s.st_gid != group)
 				return false;
@@ -1053,14 +1057,15 @@ TEST_F(permissions, fchown)
 	/* ruid=euid=fsuid=0, rgid=egid=fsgid=0 */
 
 	ASSERT_TRUE(test_fchown(pfp, f, 0, 0, 0));
-	ASSERT_TRUE(test_fchown(pfp, f, (uid_t)-1, 0, 0));
-	ASSERT_TRUE(test_fchown(pfp, f, 0, (gid_t)-1, 0));
-	ASSERT_TRUE(test_fchown(pfp, f, (uid_t)-1, (gid_t)-1, 0));
+	ASSERT_TRUE(test_fchown(pfp, f, (pmemfile_uid_t)-1, 0, 0));
+	ASSERT_TRUE(test_fchown(pfp, f, 0, (pmemfile_gid_t)-1, 0));
+	ASSERT_TRUE(
+		test_fchown(pfp, f, (pmemfile_uid_t)-1, (pmemfile_gid_t)-1, 0));
 
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 0, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 0, 1001, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1001, EPERM));
-	ASSERT_TRUE(test_fchown(pfp, f, (uid_t)-1, 1001, EPERM));
+	ASSERT_TRUE(test_fchown(pfp, f, (pmemfile_uid_t)-1, 1001, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1002, EPERM));
 
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 0, EPERM));
@@ -1079,7 +1084,7 @@ TEST_F(permissions, fchown)
 	ASSERT_TRUE(test_fchown(pfp, f, 0, 1001, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1000, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1001, EPERM));
-	ASSERT_TRUE(test_fchown(pfp, f, (uid_t)-1, 1001, EPERM));
+	ASSERT_TRUE(test_fchown(pfp, f, (pmemfile_uid_t)-1, 1001, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1002, EPERM));
 
 	ASSERT_EQ(pmemfile_setfsgid(pfp, 1001), 0);
@@ -1090,10 +1095,10 @@ TEST_F(permissions, fchown)
 	ASSERT_TRUE(test_fchown(pfp, f, 0, 1001, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1000, EPERM));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1001, 0));
-	ASSERT_TRUE(test_fchown(pfp, f, (uid_t)-1, 1001, 0));
+	ASSERT_TRUE(test_fchown(pfp, f, (pmemfile_uid_t)-1, 1001, 0));
 	ASSERT_TRUE(test_fchown(pfp, f, 1000, 1002, EPERM));
 
-	gid_t groups[1] = {1002};
+	pmemfile_gid_t groups[1] = {1002};
 	ASSERT_EQ(pmemfile_setgroups(pfp, 1, groups), 0);
 
 	/* ruid=euid=0 fsuid=1000, rgid=egid=0 fsgid=1001, gids=1002 */
@@ -1115,7 +1120,7 @@ TEST_F(permissions, lchown)
 	ASSERT_EQ(pmemfile_setreuid(pfp, 1000, 1000), 0);
 	ASSERT_EQ(pmemfile_setregid(pfp, 1001, 1001), 0);
 
-	gid_t groups[1] = {1002};
+	pmemfile_gid_t groups[1] = {1002};
 	ASSERT_EQ(pmemfile_setgroups(pfp, 1, groups), 0);
 
 	ASSERT_TRUE(test_pmemfile_create(pfp, "/file", PMEMFILE_O_EXCL,
@@ -1126,22 +1131,22 @@ TEST_F(permissions, lchown)
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_stat(pfp, "/file", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)1001);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)1001);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_lstat(pfp, "/symlink", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)1001);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)1001);
 
-	ASSERT_EQ(pmemfile_lchown(pfp, "/symlink", (uid_t)-1, 1002), 0)
+	ASSERT_EQ(pmemfile_lchown(pfp, "/symlink", (pmemfile_uid_t)-1, 1002), 0)
 		<< strerror(errno);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_stat(pfp, "/file", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)1001);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)1001);
 
 	memset(&s, 0, sizeof(s));
 	ASSERT_EQ(pmemfile_lstat(pfp, "/symlink", &s), 0);
-	ASSERT_EQ(s.st_gid, (gid_t)1002);
+	ASSERT_EQ(s.st_gid, (pmemfile_gid_t)1002);
 
 	ASSERT_EQ(pmemfile_unlink(pfp, "/symlink"), 0);
 	ASSERT_EQ(pmemfile_unlink(pfp, "/file"), 0);

--- a/tests/posix/permissions/permissions.cpp
+++ b/tests/posix/permissions/permissions.cpp
@@ -46,7 +46,7 @@ public:
 TEST_F(permissions, chmod)
 {
 	PMEMfile *f;
-	struct stat statbuf;
+	pmemfile_stat_t statbuf;
 
 	ASSERT_TRUE(test_pmemfile_create(pfp, "/aaa", PMEMFILE_O_EXCL,
 					 PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
@@ -165,7 +165,7 @@ TEST_F(permissions, chmod)
 
 TEST_F(permissions, symlink)
 {
-	struct stat statbuf;
+	pmemfile_stat_t statbuf;
 	ASSERT_TRUE(test_pmemfile_create(pfp, "/aaa", PMEMFILE_O_EXCL,
 					 PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
 						 PMEMFILE_S_IRGRP |
@@ -211,7 +211,7 @@ TEST_F(permissions, symlink)
 TEST_F(permissions, reuid_regid_fsuid_fsgid_getgroups_setgroups)
 {
 	PMEMfile *f;
-	struct stat statbuf;
+	pmemfile_stat_t statbuf;
 	int prev_uid;
 	int prev_gid;
 
@@ -333,7 +333,7 @@ TEST_F(permissions, chmod_and_cap)
 TEST_F(permissions, fchmod)
 {
 	PMEMfile *f;
-	struct stat statbuf;
+	pmemfile_stat_t statbuf;
 
 	ASSERT_TRUE(test_pmemfile_create(pfp, "/aaa", PMEMFILE_O_EXCL,
 					 PMEMFILE_S_IRUSR | PMEMFILE_S_IWUSR |
@@ -373,7 +373,7 @@ TEST_F(permissions, fchmod)
 TEST_F(permissions, fchmodat)
 {
 	PMEMfile *dir;
-	struct stat statbuf;
+	pmemfile_stat_t statbuf;
 
 	ASSERT_EQ(pmemfile_mkdir(pfp, "/dir", PMEMFILE_S_IRWXU), 0);
 
@@ -894,7 +894,7 @@ test_chown(PMEMfilepool *pfp, const char *pathname, pmemfile_uid_t owner,
 		if (r != 0)
 			return false;
 
-		struct stat s;
+		pmemfile_stat_t s;
 		memset(&s, 0, sizeof(s));
 		if (pmemfile_stat(pfp, pathname, &s)) {
 			ADD_FAILURE() << "stat failed " << strerror(errno);
@@ -919,7 +919,7 @@ test_chown(PMEMfilepool *pfp, const char *pathname, pmemfile_uid_t owner,
 
 TEST_F(permissions, chown)
 {
-	struct stat s;
+	pmemfile_stat_t s;
 
 	ASSERT_TRUE(test_pmemfile_create(pfp, "/file", PMEMFILE_O_EXCL,
 					 PMEMFILE_S_IRWXU));
@@ -1024,7 +1024,7 @@ test_fchown(PMEMfilepool *pfp, PMEMfile *f, pmemfile_uid_t owner,
 		if (r != 0)
 			return false;
 
-		struct stat s;
+		pmemfile_stat_t s;
 		memset(&s, 0, sizeof(s));
 		if (pmemfile_fstat(pfp, f, &s)) {
 			ADD_FAILURE() << "stat failed " << strerror(errno);
@@ -1115,7 +1115,7 @@ TEST_F(permissions, fchown)
 
 TEST_F(permissions, lchown)
 {
-	struct stat s;
+	pmemfile_stat_t s;
 
 	ASSERT_EQ(pmemfile_setreuid(pfp, 1000, 1000), 0);
 	ASSERT_EQ(pmemfile_setregid(pfp, 1001, 1001), 0);

--- a/tests/posix/pmemfile_test.cpp
+++ b/tests/posix/pmemfile_test.cpp
@@ -77,7 +77,7 @@ test_pmemfile_create(PMEMfilepool *pfp, const char *path, int flags,
 pmemfile_ssize_t
 test_pmemfile_file_size(PMEMfilepool *pfp, PMEMfile *file)
 {
-	struct stat buf;
+	pmemfile_stat_t buf;
 	int ret = pmemfile_fstat(pfp, file, &buf);
 	EXPECT_EQ(ret, 0) << strerror(errno);
 	if (ret != 0)
@@ -88,7 +88,7 @@ test_pmemfile_file_size(PMEMfilepool *pfp, PMEMfile *file)
 pmemfile_ssize_t
 test_pmemfile_path_size(PMEMfilepool *pfp, const char *path)
 {
-	struct stat buf;
+	pmemfile_stat_t buf;
 	int ret = pmemfile_stat(pfp, path, &buf);
 	EXPECT_EQ(ret, 0) << strerror(errno);
 	if (ret != 0)
@@ -124,7 +124,7 @@ std::map<std::string, file_attrs>
 test_list_files(PMEMfilepool *pfp, PMEMfile *dir, const char *dirp,
 		unsigned length)
 {
-	struct stat statbuf;
+	pmemfile_stat_t statbuf;
 	char symlinkbuf[PMEMFILE_PATH_MAX];
 	std::map<std::string, file_attrs> retmap;
 	bool err = false;

--- a/tests/posix/pmemfile_test.cpp
+++ b/tests/posix/pmemfile_test.cpp
@@ -63,7 +63,7 @@ test_pmemfile_stats_match(PMEMfilepool *pfp, unsigned inodes, unsigned dirs,
 
 bool
 test_pmemfile_create(PMEMfilepool *pfp, const char *path, int flags,
-		     mode_t mode)
+		     pmemfile_mode_t mode)
 {
 	PMEMfile *file =
 		pmemfile_open(pfp, path, flags | PMEMFILE_O_CREAT, mode);
@@ -74,7 +74,7 @@ test_pmemfile_create(PMEMfilepool *pfp, const char *path, int flags,
 	return true;
 }
 
-ssize_t
+pmemfile_ssize_t
 test_pmemfile_file_size(PMEMfilepool *pfp, PMEMfile *file)
 {
 	struct stat buf;
@@ -85,7 +85,7 @@ test_pmemfile_file_size(PMEMfilepool *pfp, PMEMfile *file)
 	return buf.st_size;
 }
 
-ssize_t
+pmemfile_ssize_t
 test_pmemfile_path_size(PMEMfilepool *pfp, const char *path)
 {
 	struct stat buf;
@@ -156,9 +156,9 @@ test_list_files(PMEMfilepool *pfp, PMEMfile *dir, const char *dirp,
 		} else if (type == PMEMFILE_DT_LNK) {
 			MODE_EXPECT(PMEMFILE_S_ISLNK, statbuf.st_mode, 1);
 
-			ssize_t ret = pmemfile_readlinkat(pfp, dir, dirp + i,
-							  symlinkbuf,
-							  PMEMFILE_PATH_MAX);
+			pmemfile_ssize_t ret = pmemfile_readlinkat(
+				pfp, dir, dirp + i, symlinkbuf,
+				PMEMFILE_PATH_MAX);
 			tmp = ret <= 0 || ret >= PMEMFILE_PATH_MAX;
 			if (tmp)
 				ADD_FAILURE() << ret;

--- a/tests/posix/pmemfile_test.hpp
+++ b/tests/posix/pmemfile_test.hpp
@@ -65,26 +65,26 @@ is_zeroed(const void *addr, size_t len)
 
 /* pmemfile stuff */
 bool test_pmemfile_create(PMEMfilepool *pfp, const char *path, int flags,
-			  mode_t mode);
+			  pmemfile_mode_t mode);
 /* utilities */
 
 class pmemfile_ls {
 public:
-	mode_t mode;
-	nlink_t nlink;
-	off_t size;
+	pmemfile_mode_t mode;
+	pmemfile_nlink_t nlink;
+	pmemfile_off_t size;
 	const char *name;
 	const char *link;
 
-	uid_t uid;
-	gid_t gid;
+	pmemfile_uid_t uid;
+	pmemfile_gid_t gid;
 };
 
 bool test_pmemfile_stats_match(PMEMfilepool *pfp, unsigned inodes,
 			       unsigned dirs, unsigned block_arrays,
 			       unsigned blocks);
-ssize_t test_pmemfile_file_size(PMEMfilepool *pfp, PMEMfile *file);
-ssize_t test_pmemfile_path_size(PMEMfilepool *pfp, const char *path);
+pmemfile_ssize_t test_pmemfile_file_size(PMEMfilepool *pfp, PMEMfile *file);
+pmemfile_ssize_t test_pmemfile_path_size(PMEMfilepool *pfp, const char *path);
 
 class file_attrs {
 public:

--- a/tests/posix/pmemfile_test.hpp
+++ b/tests/posix/pmemfile_test.hpp
@@ -88,10 +88,10 @@ pmemfile_ssize_t test_pmemfile_path_size(PMEMfilepool *pfp, const char *path);
 
 class file_attrs {
 public:
-	struct stat stat;
+	pmemfile_stat_t stat;
 	std::string link;
 
-	file_attrs(const struct stat &stat, const char *link = nullptr)
+	file_attrs(const pmemfile_stat_t &stat, const char *link = nullptr)
 	    : stat(stat), link(link)
 	{
 	}

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -48,7 +48,7 @@ protected:
 	pmemfile_blkcnt_t
 	stat_block_count(PMEMfile *f)
 	{
-		struct stat stat_buf;
+		pmemfile_stat_t stat_buf;
 
 		if (pmemfile_fstat(pfp, f, &stat_buf) != 0) {
 			perror("stat_block_count");

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -45,7 +45,7 @@ public:
 	}
 
 protected:
-	blkcnt_t
+	pmemfile_blkcnt_t
 	stat_block_count(PMEMfile *f)
 	{
 		struct stat stat_buf;
@@ -82,8 +82,8 @@ TEST_F(rw, 1)
 	memset(bufFF, 0xff, sizeof(bufFF));
 	memset(buf00, 0x00, sizeof(buf00));
 
-	ssize_t written = pmemfile_write(pfp, f, data, len);
-	ASSERT_EQ(written, (ssize_t)len) << COND_ERROR(written);
+	pmemfile_ssize_t written = pmemfile_write(pfp, f, data, len);
+	ASSERT_EQ(written, (pmemfile_ssize_t)len) << COND_ERROR(written);
 
 	EXPECT_TRUE(
 		test_compare_dirs(pfp, "/", std::vector<pmemfile_ls>{
@@ -95,7 +95,7 @@ TEST_F(rw, 1)
 	EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 1));
 
 	/* try to read write-only file */
-	ssize_t r = pmemfile_read(pfp, f, data2, len);
+	pmemfile_ssize_t r = pmemfile_read(pfp, f, data2, len);
 	ASSERT_EQ(r, -1);
 	EXPECT_EQ(errno, EBADF);
 	pmemfile_close(pfp, f);
@@ -106,7 +106,7 @@ TEST_F(rw, 1)
 	/* read only what we wrote and check nothing else was read */
 	memset(data2, 0xff, sizeof(data2));
 	r = pmemfile_read(pfp, f, data2, len);
-	ASSERT_EQ(r, (ssize_t)len) << COND_ERROR(r);
+	ASSERT_EQ(r, (pmemfile_ssize_t)len) << COND_ERROR(r);
 	ASSERT_EQ(memcmp(data, data2, len), 0);
 	ASSERT_EQ(memcmp(data2 + len, bufFF, sizeof(data2) - len), 0);
 
@@ -129,7 +129,7 @@ TEST_F(rw, 1)
 	/* read as much as possible and check that we read only what we wrote */
 	memset(data2, 0xff, sizeof(data2));
 	r = pmemfile_read(pfp, f, data2, sizeof(data2));
-	ASSERT_EQ(r, (ssize_t)len);
+	ASSERT_EQ(r, (pmemfile_ssize_t)len);
 	ASSERT_EQ(memcmp(data, data2, len), 0);
 	ASSERT_EQ(memcmp(data2 + len, bufFF, sizeof(data2) - len), 0);
 
@@ -339,8 +339,9 @@ TEST_F(rw, 2)
 #define LEN (sizeof(bufd) - 1000)
 #define LOOPS ((200 * 1024 * 1024) / LEN)
 	for (size_t i = 0; i < LOOPS; ++i) {
-		ssize_t written = pmemfile_write(pfp, f, bufd, LEN);
-		ASSERT_EQ(written, (ssize_t)LEN) << COND_ERROR(written);
+		pmemfile_ssize_t written = pmemfile_write(pfp, f, bufd, LEN);
+		ASSERT_EQ(written, (pmemfile_ssize_t)LEN)
+			<< COND_ERROR(written);
 	}
 
 	pmemfile_close(pfp, f);
@@ -359,12 +360,12 @@ TEST_F(rw, 2)
 
 	f = pmemfile_open(pfp, "/file1", PMEMFILE_O_RDONLY);
 	ASSERT_NE(f, nullptr) << strerror(errno);
-	ssize_t r;
+	pmemfile_ssize_t r;
 
 	for (size_t i = 0; i < LOOPS; ++i) {
 		memset(buftmp, 0, sizeof(buftmp));
 		r = pmemfile_read(pfp, f, buftmp, LEN);
-		ASSERT_EQ(r, (ssize_t)LEN) << COND_ERROR(r);
+		ASSERT_EQ(r, (pmemfile_ssize_t)LEN) << COND_ERROR(r);
 		ASSERT_EQ(memcmp(buftmp, bufd, LEN), 0);
 	}
 #undef LEN
@@ -423,7 +424,7 @@ TEST_F(rw, trunc)
 			   0);
 	ASSERT_NE(f2, nullptr) << strerror(errno);
 
-	ssize_t r = pmemfile_read(pfp, f1, buftmp, 128);
+	pmemfile_ssize_t r = pmemfile_read(pfp, f1, buftmp, 128);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
 
 	ASSERT_EQ(pmemfile_write(pfp, f2, bufDD, 128), 128);
@@ -450,7 +451,7 @@ TEST_F(rw, ftruncate)
 	char buf[0x1000];
 	char bufFF[sizeof(buf)];
 	PMEMfile *f;
-	ssize_t r;
+	pmemfile_ssize_t r;
 
 	memset(bufFF, 0xff, sizeof(bufFF));
 
@@ -473,7 +474,7 @@ TEST_F(rw, ftruncate)
 
 	EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 0));
 
-	static const ssize_t large = 0x100000;
+	static const pmemfile_ssize_t large = 0x100000;
 
 	r = pmemfile_ftruncate(pfp, f, large / 32);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
@@ -487,7 +488,7 @@ TEST_F(rw, ftruncate)
 	ASSERT_EQ(test_pmemfile_path_size(pfp, "/file1"), large + 4);
 
 	static constexpr char data0[] = "testtest";
-	static constexpr ssize_t l0 = sizeof(data0) - 1;
+	static constexpr pmemfile_ssize_t l0 = sizeof(data0) - 1;
 
 	ASSERT_EQ(pmemfile_lseek(pfp, f, large, PMEMFILE_SEEK_SET), large);
 	ASSERT_EQ(pmemfile_write(pfp, f, data0, l0), l0);
@@ -498,7 +499,7 @@ TEST_F(rw, ftruncate)
 	ASSERT_EQ(memcmp(buf, bufFF, sizeof(buf)), 0);
 
 	static constexpr char data1[] = "\0\0\0testtest";
-	static constexpr ssize_t l1 = sizeof(data1) - 1;
+	static constexpr pmemfile_ssize_t l1 = sizeof(data1) - 1;
 
 	ASSERT_EQ(pmemfile_lseek(pfp, f, large, PMEMFILE_SEEK_SET), large);
 	ASSERT_EQ(pmemfile_lseek(pfp, f, -3, PMEMFILE_SEEK_CUR), large - 3);
@@ -514,7 +515,7 @@ TEST_F(rw, ftruncate)
 		EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 2));
 
 	static constexpr char data2[] = "\0\0\0te";
-	static constexpr ssize_t l2 = sizeof(data2) - 1;
+	static constexpr pmemfile_ssize_t l2 = sizeof(data2) - 1;
 
 	r = pmemfile_ftruncate(pfp, f, large + 2);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
@@ -533,7 +534,7 @@ TEST_F(rw, ftruncate)
 		EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 2));
 
 	static constexpr char data3[] = "\0\0\0te\0\0\0\0\0\0";
-	static constexpr ssize_t l3 = sizeof(data3) - 1;
+	static constexpr pmemfile_ssize_t l3 = sizeof(data3) - 1;
 
 	r = pmemfile_ftruncate(pfp, f, large + 8);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
@@ -567,7 +568,7 @@ TEST_F(rw, truncate)
 	char buf[0x1000];
 	char bufFF[sizeof(buf)];
 	PMEMfile *f;
-	ssize_t r;
+	pmemfile_ssize_t r;
 
 	memset(bufFF, 0xff, sizeof(bufFF));
 
@@ -591,7 +592,7 @@ TEST_F(rw, truncate)
 
 	EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 0));
 
-	static const ssize_t large = 0x100000;
+	static const pmemfile_ssize_t large = 0x100000;
 
 	r = pmemfile_truncate(pfp, "/file1", large / 32);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
@@ -605,7 +606,7 @@ TEST_F(rw, truncate)
 	ASSERT_EQ(test_pmemfile_path_size(pfp, "/file1"), large + 4);
 
 	static constexpr char data0[] = "testtest";
-	static constexpr ssize_t l0 = sizeof(data0) - 1;
+	static constexpr pmemfile_ssize_t l0 = sizeof(data0) - 1;
 
 	ASSERT_EQ(pmemfile_lseek(pfp, f, large, PMEMFILE_SEEK_SET), large);
 	ASSERT_EQ(pmemfile_write(pfp, f, data0, l0), l0);
@@ -616,7 +617,7 @@ TEST_F(rw, truncate)
 	ASSERT_EQ(memcmp(buf, bufFF, sizeof(buf)), 0);
 
 	static constexpr char data1[] = "\0\0\0testtest";
-	static constexpr ssize_t l1 = sizeof(data1) - 1;
+	static constexpr pmemfile_ssize_t l1 = sizeof(data1) - 1;
 
 	ASSERT_EQ(pmemfile_lseek(pfp, f, large, PMEMFILE_SEEK_SET), large);
 	ASSERT_EQ(pmemfile_lseek(pfp, f, -3, PMEMFILE_SEEK_CUR), large - 3);
@@ -632,7 +633,7 @@ TEST_F(rw, truncate)
 		EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 2));
 
 	static constexpr char data2[] = "\0\0\0te";
-	static constexpr ssize_t l2 = sizeof(data2) - 1;
+	static constexpr pmemfile_ssize_t l2 = sizeof(data2) - 1;
 
 	r = pmemfile_truncate(pfp, "/file1", large + 2);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
@@ -651,7 +652,7 @@ TEST_F(rw, truncate)
 		EXPECT_TRUE(test_pmemfile_stats_match(pfp, 2, 0, 0, 2));
 
 	static constexpr char data3[] = "\0\0\0te\0\0\0\0\0\0";
-	static constexpr ssize_t l3 = sizeof(data3) - 1;
+	static constexpr pmemfile_ssize_t l3 = sizeof(data3) - 1;
 
 	r = pmemfile_truncate(pfp, "/file1", large + 8);
 	ASSERT_EQ(r, 0) << COND_ERROR(r);
@@ -686,7 +687,7 @@ TEST_F(rw, fallocate)
 	char buf00[sizeof(buf)];
 	char bufFF[sizeof(buf)];
 	PMEMfile *f;
-	ssize_t r;
+	pmemfile_ssize_t r;
 
 	memset(buf00, 0x00, sizeof(buf00));
 	memset(bufFF, 0xff, sizeof(bufFF));
@@ -753,7 +754,7 @@ TEST_F(rw, fallocate)
 	 * the block size is fixed to 4K bytes.
 	 */
 	static constexpr char data0[] = "testing testy tested tests";
-	static constexpr ssize_t l0 = sizeof(data0) - 1;
+	static constexpr pmemfile_ssize_t l0 = sizeof(data0) - 1;
 
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 0x1ffe, PMEMFILE_SEEK_SET), 0x1ffe);
 	ASSERT_EQ(pmemfile_write(pfp, f, data0, l0), l0);
@@ -769,7 +770,7 @@ TEST_F(rw, fallocate)
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 0x1ffd, PMEMFILE_SEEK_SET), 0x1ffd);
 	memset(buf, 0xff, sizeof(buf));
 	r = pmemfile_read(pfp, f, buf, sizeof(buf));
-	ASSERT_EQ(r, (ssize_t)sizeof(buf)) << COND_ERROR(r);
+	ASSERT_EQ(r, (pmemfile_ssize_t)sizeof(buf)) << COND_ERROR(r);
 	ASSERT_EQ(buf[0], '\0');
 	ASSERT_EQ(memcmp(buf + 1, data0, l0), 0);
 	ASSERT_EQ(memcmp(buf + 1 + l0, buf00, sizeof(buf) - 1 - l0), 0);
@@ -799,7 +800,7 @@ TEST_F(rw, fallocate)
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 0x1ffd, PMEMFILE_SEEK_SET), 0x1ffd);
 	memset(buf, 0xff, sizeof(buf));
 	r = pmemfile_read(pfp, f, buf, sizeof(buf));
-	ASSERT_EQ(r, (ssize_t)sizeof(buf)) << COND_ERROR(r);
+	ASSERT_EQ(r, (pmemfile_ssize_t)sizeof(buf)) << COND_ERROR(r);
 	ASSERT_EQ(buf[0], '\0');
 	ASSERT_EQ(memcmp(buf + 1, data0, 2), 0);
 	ASSERT_EQ(memcmp(buf + 1 + 2, buf00, sizeof(buf) - 1 - 2), 0);
@@ -839,7 +840,7 @@ TEST_F(rw, fallocate)
 	 * Altering the file size as well this time.
 	 */
 	/* Remember the the expected size and block counts at this point */
-	static constexpr ssize_t size = 0x80000 + 0x4000;
+	static constexpr pmemfile_ssize_t size = 0x80000 + 0x4000;
 	static constexpr unsigned bc_4k = 14 + 4;
 	static constexpr unsigned bc = 2;
 	r = pmemfile_fallocate(pfp, f, 0, 0x80000, 0x4000);
@@ -868,7 +869,7 @@ TEST_F(rw, fallocate)
 	/*
 	 * How about allocating a lot of single byte intervals?
 	 */
-	for (ssize_t offset = 77; offset < size; offset += 0x1000) {
+	for (pmemfile_ssize_t offset = 77; offset < size; offset += 0x1000) {
 		r = pmemfile_fallocate(pfp, f, PMEMFILE_FL_KEEP_SIZE, offset,
 				       1);
 		ASSERT_EQ(r, 0) << strerror(errno);
@@ -980,10 +981,10 @@ TEST_F(rw, o_append)
 
 TEST_F(rw, sparse_files_using_lseek)
 {
-	ssize_t size;
-	ssize_t r;
-	ssize_t hole;
-	ssize_t hole_end;
+	pmemfile_ssize_t size;
+	pmemfile_ssize_t r;
+	pmemfile_ssize_t hole;
+	pmemfile_ssize_t hole_end;
 	unsigned char buf[8192];
 	PMEMfile *f;
 
@@ -1248,7 +1249,7 @@ end:
 TEST_F(rw, failed_write)
 {
 	char buf[256];
-	ssize_t r;
+	pmemfile_ssize_t r;
 
 	PMEMfile *f = pmemfile_open(pfp, "/file1", PMEMFILE_O_CREAT |
 					    PMEMFILE_O_EXCL | PMEMFILE_O_RDWR,

--- a/tests/posix/stat/stat.cpp
+++ b/tests/posix/stat/stat.cpp
@@ -46,15 +46,16 @@ public:
 static bool verbose;
 
 static const char *
-timespec_to_str(const struct timespec *t)
+timespec_to_str(const pmemfile_timespec_t *t)
 {
-	char *s = asctime(localtime(&t->tv_sec));
+	time_t sec = t->tv_sec;
+	char *s = asctime(localtime(&sec));
 	s[strlen(s) - 1] = 0;
 	return s;
 }
 
 static void
-dump_stat(struct stat *st, const char *path)
+dump_stat(pmemfile_stat_t *st, const char *path)
 {
 	T_OUT("path:       %s\n", path);
 	T_OUT("st_dev:     0x%lx\n", st->st_dev);
@@ -81,7 +82,7 @@ test_stat(PMEMfilepool *pfp, const char *path, pmemfile_mode_t mode = 0,
 	  pmemfile_nlink_t nlink = 0, pmemfile_off_t size = 0,
 	  pmemfile_blksize_t blksize = 0, pmemfile_blkcnt_t blocks = 0)
 {
-	struct stat st;
+	pmemfile_stat_t st;
 	memset(&st, 0, sizeof(st));
 	int ret = pmemfile_stat(pfp, path, &st);
 	if (ret)
@@ -106,7 +107,7 @@ test_fstat(PMEMfilepool *pfp, PMEMfile *f, pmemfile_mode_t mode = 0,
 	   pmemfile_nlink_t nlink = 0, pmemfile_off_t size = 0,
 	   pmemfile_blksize_t blksize = 0, pmemfile_blkcnt_t blocks = 0)
 {
-	struct stat st;
+	pmemfile_stat_t st;
 	memset(&st, 0, sizeof(st));
 	int ret = pmemfile_fstat(pfp, f, &st);
 	if (ret)
@@ -132,7 +133,7 @@ test_fstatat(PMEMfilepool *pfp, PMEMfile *dir, const char *path, int flags,
 	     pmemfile_off_t size = 0, pmemfile_blksize_t blksize = 0,
 	     pmemfile_blkcnt_t blocks = 0)
 {
-	struct stat st;
+	pmemfile_stat_t st;
 	memset(&st, 0, sizeof(st));
 	int ret = pmemfile_fstatat(pfp, dir, path, &st, flags);
 	if (ret)

--- a/tests/posix/stat/stat.cpp
+++ b/tests/posix/stat/stat.cpp
@@ -77,9 +77,9 @@ dump_stat(struct stat *st, const char *path)
 }
 
 static int
-test_stat(PMEMfilepool *pfp, const char *path, mode_t mode = 0,
-	  nlink_t nlink = 0, off_t size = 0, blksize_t blksize = 0,
-	  blkcnt_t blocks = 0)
+test_stat(PMEMfilepool *pfp, const char *path, pmemfile_mode_t mode = 0,
+	  pmemfile_nlink_t nlink = 0, pmemfile_off_t size = 0,
+	  pmemfile_blksize_t blksize = 0, pmemfile_blkcnt_t blocks = 0)
 {
 	struct stat st;
 	memset(&st, 0, sizeof(st));
@@ -102,8 +102,9 @@ test_stat(PMEMfilepool *pfp, const char *path, mode_t mode = 0,
 }
 
 static int
-test_fstat(PMEMfilepool *pfp, PMEMfile *f, mode_t mode = 0, nlink_t nlink = 0,
-	   off_t size = 0, blksize_t blksize = 0, blkcnt_t blocks = 0)
+test_fstat(PMEMfilepool *pfp, PMEMfile *f, pmemfile_mode_t mode = 0,
+	   pmemfile_nlink_t nlink = 0, pmemfile_off_t size = 0,
+	   pmemfile_blksize_t blksize = 0, pmemfile_blkcnt_t blocks = 0)
 {
 	struct stat st;
 	memset(&st, 0, sizeof(st));
@@ -127,8 +128,9 @@ test_fstat(PMEMfilepool *pfp, PMEMfile *f, mode_t mode = 0, nlink_t nlink = 0,
 
 static int
 test_fstatat(PMEMfilepool *pfp, PMEMfile *dir, const char *path, int flags,
-	     mode_t mode = 0, nlink_t nlink = 0, off_t size = 0,
-	     blksize_t blksize = 0, blkcnt_t blocks = 0)
+	     pmemfile_mode_t mode = 0, pmemfile_nlink_t nlink = 0,
+	     pmemfile_off_t size = 0, pmemfile_blksize_t blksize = 0,
+	     pmemfile_blkcnt_t blocks = 0)
 {
 	struct stat st;
 	memset(&st, 0, sizeof(st));
@@ -172,7 +174,7 @@ TEST_F(stat_test, stat_big_file)
 	memset(buf, 0xdd, 1024);
 
 	for (int i = 0; i < 100; ++i) {
-		ssize_t written = pmemfile_write(pfp, f, buf, 1024);
+		pmemfile_ssize_t written = pmemfile_write(pfp, f, buf, 1024);
 		ASSERT_EQ(written, 1024) << COND_ERROR(written);
 	}
 

--- a/tests/posix/symlinks/symlinks.cpp
+++ b/tests/posix/symlinks/symlinks.cpp
@@ -48,8 +48,8 @@ test_pmemfile_readlink(PMEMfilepool *pfp, const char *pathname,
 {
 	static char readlink_buf[PMEMFILE_PATH_MAX];
 
-	ssize_t ret = pmemfile_readlink(pfp, pathname, readlink_buf,
-					sizeof(readlink_buf) - 1);
+	pmemfile_ssize_t ret = pmemfile_readlink(pfp, pathname, readlink_buf,
+						 sizeof(readlink_buf) - 1);
 	EXPECT_GT(ret, 0) << pathname << " " << errno << " " << strerror(errno);
 	if (ret <= 0)
 		return false;
@@ -79,8 +79,8 @@ test_pmemfile_readlinkat(PMEMfilepool *pfp, const char *dirpath,
 		return false;
 	}
 
-	ssize_t ret = pmemfile_readlinkat(pfp, dir, pathname, readlink_buf,
-					  sizeof(readlink_buf) - 1);
+	pmemfile_ssize_t ret = pmemfile_readlinkat(
+		pfp, dir, pathname, readlink_buf, sizeof(readlink_buf) - 1);
 	EXPECT_GT(ret, 0) << pathname << " " << errno << " " << strerror(errno);
 	pmemfile_close(pfp, dir);
 	if (ret <= 0)
@@ -154,7 +154,7 @@ TEST_F(symlinks, 0)
 			{0120777, 1, 8, "sym4-not_exists-relative", "../file2"},
 		}));
 
-	ssize_t ret;
+	pmemfile_ssize_t ret;
 
 	ret = pmemfile_symlink(pfp, "whatever", "/not-exisiting-dir/xxx");
 	ASSERT_EQ(ret, -1);
@@ -238,7 +238,7 @@ test_symlink_valid(PMEMfilepool *pfp, const char *path)
 	if (!file)
 		return false;
 
-	ssize_t r = pmemfile_read(pfp, file, buf, sizeof(buf));
+	pmemfile_ssize_t r = pmemfile_read(pfp, file, buf, sizeof(buf));
 	if (r != 7) {
 		ADD_FAILURE() << r << " " << COND_ERROR(r);
 		return false;
@@ -280,7 +280,7 @@ test_symlink_to_dir_valid(PMEMfilepool *pfp, const char *path)
 	EXPECT_NE(file, nullptr) << strerror(errno);
 	if (!file)
 		return false;
-	ssize_t r = pmemfile_read(pfp, file, buf, sizeof(buf), -1, EBADF);
+	pmemfile_ssize_t r = pmemfile_read(pfp, file, buf, sizeof(buf), -1, EBADF);
 	if (r != -1)
 		return false;
 	if (errno != EBADF)
@@ -347,7 +347,7 @@ TEST_F(symlinks, 1)
 		pmemfile_open(pfp, "/dir1/internal_dir/file",
 			      PMEMFILE_O_CREAT | PMEMFILE_O_WRONLY, 0644);
 	ASSERT_NE(file, nullptr) << strerror(errno);
-	ssize_t written = pmemfile_write(pfp, file, "qwerty\n", 7);
+	pmemfile_ssize_t written = pmemfile_write(pfp, file, "qwerty\n", 7);
 	ASSERT_EQ(written, 7) << COND_ERROR(written);
 	pmemfile_close(pfp, file);
 
@@ -385,7 +385,7 @@ TEST_F(symlinks, 2)
 		pfp, "/file1", PMEMFILE_O_CREAT | PMEMFILE_O_WRONLY, 0644);
 	ASSERT_NE(file, nullptr) << strerror(errno);
 
-	ssize_t written = pmemfile_write(pfp, file, "qwerty\n", 7);
+	pmemfile_ssize_t written = pmemfile_write(pfp, file, "qwerty\n", 7);
 	ASSERT_EQ(written, 7) << COND_ERROR(written);
 	pmemfile_close(pfp, file);
 
@@ -406,7 +406,7 @@ TEST_F(symlinks, 2)
 	file = pmemfile_open(pfp, "/file1", PMEMFILE_O_RDONLY);
 	ASSERT_NE(file, nullptr) << strerror(errno);
 
-	ssize_t r = pmemfile_read(pfp, file, buf, sizeof(buf));
+	pmemfile_ssize_t r = pmemfile_read(pfp, file, buf, sizeof(buf));
 	ASSERT_EQ(r, 7) << COND_ERROR(r);
 	pmemfile_close(pfp, file);
 	ASSERT_EQ(memcmp(buf, "qwerty\n", 7), 0);
@@ -433,7 +433,7 @@ TEST_F(symlinks, 3)
 		pfp, "/file", PMEMFILE_O_CREAT | PMEMFILE_O_WRONLY, 0644);
 	ASSERT_NE(file, nullptr) << strerror(errno);
 
-	ssize_t written = pmemfile_write(pfp, file, "qwerty\n", 7);
+	pmemfile_ssize_t written = pmemfile_write(pfp, file, "qwerty\n", 7);
 	ASSERT_EQ(written, 7) << COND_ERROR(written);
 	pmemfile_close(pfp, file);
 

--- a/tests/posix/symlinks/symlinks.cpp
+++ b/tests/posix/symlinks/symlinks.cpp
@@ -551,7 +551,7 @@ TEST_F(symlinks, 6)
 
 	ASSERT_EQ(pmemfile_symlink(pfp, "/dir2", "/dir1/symlink"), 0);
 
-	struct stat buf;
+	pmemfile_stat_t buf;
 	ASSERT_EQ(pmemfile_stat(pfp, "/dir1/symlink", &buf), 0);
 	ASSERT_EQ(PMEMFILE_S_ISLNK(buf.st_mode), 0);
 
@@ -574,7 +574,7 @@ TEST_F(symlinks, 6)
 TEST_F(symlinks, creat_excl)
 {
 	PMEMfile *file;
-	struct stat buf;
+	pmemfile_stat_t buf;
 
 	ASSERT_EQ(pmemfile_mkdir(pfp, "/dir", 0777), 0);
 	ASSERT_EQ(pmemfile_symlink(pfp, "../file", "/dir/symlink"), 0);


### PR DESCRIPTION
On Windows there are problems with types.

Some typedefs don't exist (like ssize_t) and some are wrong (like off_t being always 32-bit and off64_t not existing). The only portable way seems to be to define our own typedefs, use them everywhere and on Linux validate that they have the same size as their native counterparts.

Another problem is with "struct stat". It's defined on Windows, but it has less fields (no st_blksize and st_blocks) and fields that exist have shorter types (eg st_size is 32-bit). There's "struct \_stat64" with some of the fields bigger (st_size is 64-bit), but still some of them are too small (st_uid, st_gid, st_*time, nlink_t, st_ino). The solution presented in this PR is to define "struct pmemfile_stat" exactly like on Linux, use it and validate its size and layout matches native struct stat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/44)
<!-- Reviewable:end -->
