### PR TITLE
posix: remove PMEMFILE_AT_CWD support from fstat and fchmod

### DIFF
--- a/src/libpmemfile-core/file.c
+++ b/src/libpmemfile-core/file.c
@@ -1554,20 +1554,7 @@ pmemfile_fchmod(PMEMfilepool *pfp, PMEMfile *file, mode_t mode)
 		return -1;
 	}
 
-	struct pmemfile_vinode *vinode;
-
-	bool unref = false;
-	if (file == PMEMFILE_AT_CWD) {
-		unref = true;
-		vinode = pool_get_cwd(pfp);
-	} else {
-		vinode = file->vinode;
-	}
-
-	int ret = vinode_chmod(pfp, vinode, mode);
-
-	if (unref)
-		vinode_unref_tx(pfp, vinode);
+	int ret = vinode_chmod(pfp, file->vinode, mode);
 
 	if (ret) {
 		errno = ret;

--- a/src/libpmemfile-core/inode.c
+++ b/src/libpmemfile-core/inode.c
@@ -809,20 +809,7 @@ pmemfile_fstat(PMEMfilepool *pfp, PMEMfile *file, struct stat *buf)
 		return -1;
 	}
 
-	struct pmemfile_vinode *vinode;
-
-	bool unref = false;
-	if (file == PMEMFILE_AT_CWD) {
-		unref = true;
-		vinode = pool_get_cwd(pfp);
-	} else {
-		vinode = file->vinode;
-	}
-
-	int ret = vinode_stat(vinode, buf);
-
-	if (unref)
-		vinode_unref_tx(pfp, vinode);
+	int ret = vinode_stat(file->vinode, buf);
 
 	if (ret) {
 		errno = ret;


### PR DESCRIPTION
It's not required to be supported and I don't see why anyone
would try to pass AT_CWD to those functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/52)
<!-- Reviewable:end -->
