### PR TITLE
preload: always initialize all fields of fd_desc

### DIFF
--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -172,6 +172,7 @@ fetch_fd(long fd)
 		result.pmem_fda = fd_table[fd];
 	} else {
 		result.pmem_fda.pool = NULL;
+		result.pmem_fda.file = NULL;
 	}
 
 	return result;


### PR DESCRIPTION
It should quiet down clang analyzer warnings:
"Passed-by-value struct argument contains uninitialized data
(e.g., via the field chain: 'pmem_fda.file')"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/54)
<!-- Reviewable:end -->
