### PR TITLE
tests: speed up preload tests

### DIFF
--- a/tests/preload/preload-helpers.cmake
+++ b/tests/preload/preload-helpers.cmake
@@ -40,6 +40,8 @@ function(setup)
 endfunction()
 
 function(cleanup)
+	unset(ENV{LD_PRELOAD})
+
 	if(${TESTS_USE_FORCED_PMEM})
 		unset(ENV{PMEM_IS_PMEM_FORCE})
 	endif()


### PR DESCRIPTION
Currently LD_PRELOAD is still in effect when removing test
directory and we even unset PMEM_IS_PMEM_FORCE, so it means
that removing it steps into the pool and unlinks everything using
msync. This can't be fast.

Just unset LD_PRELOAD in cleanup().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/58)
<!-- Reviewable:end -->
