### PR TITLE
posix: remove time output argument from inode_alloc

### DIFF
--- a/src/libpmemfile-posix/dir.h
+++ b/src/libpmemfile-posix/dir.h
@@ -77,7 +77,7 @@ void vinode_add_dirent(PMEMfilepool *pfp,
 		const char *name,
 		size_t namelen,
 		struct pmemfile_vinode *child_vinode,
-		const struct pmemfile_time *tm);
+		struct pmemfile_time tm);
 
 void vinode_set_debug_path_locked(PMEMfilepool *pfp,
 		struct pmemfile_vinode *parent_vinode,

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -470,9 +470,8 @@ file_get_time(struct pmemfile_time *t)
  * Must be called in transaction.
  */
 struct pmemfile_vinode *
-inode_alloc(PMEMfilepool *pfp, uint64_t flags, struct pmemfile_time *t,
-		struct pmemfile_vinode *parent, volatile bool *parent_refed,
-		const char *name, size_t namelen)
+inode_alloc(PMEMfilepool *pfp, uint64_t flags, struct pmemfile_vinode *parent,
+		volatile bool *parent_refed, const char *name, size_t namelen)
 {
 	LOG(LDBG, "flags 0x%lx", flags);
 
@@ -481,13 +480,14 @@ inode_alloc(PMEMfilepool *pfp, uint64_t flags, struct pmemfile_time *t,
 	TOID(struct pmemfile_inode) tinode = TX_ZNEW(struct pmemfile_inode);
 	struct pmemfile_inode *inode = D_RW(tinode);
 
-	file_get_time(t);
+	struct pmemfile_time t;
+	file_get_time(&t);
 
 	inode->version = PMEMFILE_INODE_VERSION(1);
 	inode->flags = flags;
-	inode->ctime = *t;
-	inode->mtime = *t;
-	inode->atime = *t;
+	inode->ctime = t;
+	inode->mtime = t;
+	inode->atime = t;
 	inode->nlink = 0;
 	os_rwlock_rdlock(&pfp->cred_rwlock);
 	inode->uid = pfp->cred.fsuid;

--- a/src/libpmemfile-posix/inode.h
+++ b/src/libpmemfile-posix/inode.h
@@ -139,7 +139,7 @@ static inline bool vinode_is_symlink(struct pmemfile_vinode *vinode)
 void file_get_time(struct pmemfile_time *t);
 
 struct pmemfile_vinode *inode_alloc(PMEMfilepool *pfp,
-		uint64_t flags, struct pmemfile_time *t,
+		uint64_t flags,
 		struct pmemfile_vinode *parent,
 		volatile bool *parent_refed,
 		const char *name,


### PR DESCRIPTION
We can get the creation time on an inode directly from it, instead
of returning it in the output parameter.

This should make the code less confusing both to automatic and human
static analyzers ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/60)
<!-- Reviewable:end -->
