### PR TITLE
posix: fix vinode_truncate

### DIFF
--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -1100,9 +1100,6 @@ vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 {
 	struct pmemfile_inode *inode = vinode->inode;
 
-	if (inode->size == size)
-		return;
-
 	if (vinode->blocks == NULL)
 		vinode_rebuild_block_tree(vinode);
 
@@ -1115,18 +1112,19 @@ vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 	 * Setting all the next and prev fields is pointless, when all the
 	 * blocks are removed.
 	 */
-	if (inode->size > size)
-		vinode_remove_interval(vinode, size, UINT64_MAX - size);
-	else
+	vinode_remove_interval(vinode, size, UINT64_MAX - size);
+	if (inode->size < size)
 		vinode_allocate_interval(pfp, vinode,
 		    inode->size, size - inode->size);
 
-	TX_ADD_DIRECT(&inode->size);
-	inode->size = size;
+	if (inode->size != size) {
+		TX_ADD_DIRECT(&inode->size);
+		inode->size = size;
 
-	struct pmemfile_time tm;
-	file_get_time(&tm);
-	TX_SET_DIRECT(inode, mtime, tm);
+		struct pmemfile_time tm;
+		file_get_time(&tm);
+		TX_SET_DIRECT(inode, mtime, tm);
+	}
 }
 
 void


### PR DESCRIPTION
Truncating did never remove any blocks with offsets
above file size. This problem can't be reproduced
without pmemfile_fallocate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/74)
<!-- Reviewable:end -->
